### PR TITLE
Fixed several problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+#ant stuff
+/bin/
+/download/
+#Remove OS generated garbage
+*/.DS_Store
+.DS_Store
+.DS_Store?
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+#gradle stuff
+/.gradle
+/build/
+/libs/
+/run*/
+/ui/
+*.launch
+gradle-app.setting
+#IDEA files from Gradle
+.idea/
+/*.iml
+/*.ipr
+/*.iws
+#Vim backups
+*~
+#manual version override
+version.properties
+#eclipse stuffs
+/.classpath
+/.project
+/.settings/
+/eclipse/
+/debug/
+*.lock
+/.metadata/
+/config/
+/logs/
+options.txt
+/saves/
+/out
+/src_old
+/resources_old
+/resources/assets/tinker
+/resources/assets/unused
+/design

--- a/src/main/java/com/direwolf20/buildinggadgets/CommonProxy.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/CommonProxy.java
@@ -48,7 +48,6 @@ public class CommonProxy {
 
     @SubscribeEvent
     public static void registerItems(RegistryEvent.Register<Item> event) {
-        event.getRegistry().register(new ItemBlock(ModBlocks.effectBlock).setRegistryName(ModBlocks.effectBlock.getRegistryName()));
         event.getRegistry().register(new BuildingTool());
         event.getRegistry().register(new ExchangerTool());
     }

--- a/src/main/java/com/direwolf20/buildinggadgets/blocks/EffectBlock.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/blocks/EffectBlock.java
@@ -2,13 +2,17 @@ package com.direwolf20.buildinggadgets.blocks;
 
 import com.direwolf20.buildinggadgets.BuildingGadgets;
 import net.minecraft.block.Block;
+import net.minecraft.block.material.EnumPushReaction;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.entity.Entity;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumBlockRenderType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -19,7 +23,9 @@ public class EffectBlock extends Block {
 
     public EffectBlock() {
         super(Material.ROCK);
-        setHardness(20.0f);
+        setBlockUnbreakable();      // Sets the block hardness to -1 (same as bedrock)
+        setResistance(6000000.0F);  // Sets the block blast resistance to that of bedrock
+        disableStats();             // Disables block stats from appearing on the stats screen
         setUnlocalizedName(BuildingGadgets.MODID + ".effectblock");     // Used for localization (en_US.lang)
         setRegistryName("effectblock");        // The unique name (within your mod) that identifies this block
     }
@@ -52,5 +58,16 @@ public class EffectBlock extends Block {
     @Override
     public Item getItemDropped(IBlockState state, Random rand, int fortune) {
         return Items.AIR;
+    }
+
+    @Override
+    public boolean canEntityDestroy(IBlockState state, IBlockAccess world, BlockPos pos, Entity entity) {
+        return false;
+    }
+
+    @Override
+    public EnumPushReaction getMobilityFlag(IBlockState state)
+    {
+        return EnumPushReaction.BLOCK;  // Prevents block from being pushed by pistons
     }
 }


### PR DESCRIPTION
### Remove EffectBlock's item registration
Blocks that are never intended to find their way into the player's inventory don't need an item registration  
  
This fixes being able to give yourself the effectblock using /give  
### Prevent effectblock from being destroyed by explosions or moved by pistons
Fixes creating lingering effect blocks by using pistons, as well as makes the blocks indestructable
### Write BlockBuildEntity to NBT so logging out is no longer a problem
As the entity didn't remember its state, it would lose all its data when it was unloaded and therefore left lingering effect blocks around

This may fix #4 
### Added gitignore
The project was very difficult to contribute to without the gitignore as every irrelevant file got staged