### PR TITLE
 Allow tools to be configured not to take damage and not use energy.

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/items/BuildingTool.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/items/BuildingTool.java
@@ -320,7 +320,9 @@ public class BuildingTool extends GenericGadget {
             }
         } else {
             if (heldItem.getItemDamage() >= heldItem.getMaxDamage()) {
-                return false;
+                if (heldItem.isItemStackDamageable()) {
+                    return false;
+                }
             } else {
                 heldItem.damageItem(1, player);
             }

--- a/src/main/java/com/direwolf20/buildinggadgets/items/CopyPasteTool.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/items/CopyPasteTool.java
@@ -558,7 +558,9 @@ public class CopyPasteTool extends GenericGadget {
             }
         } else {
             if (heldItem.getItemDamage() >= heldItem.getMaxDamage()) {
-                return;
+                if (heldItem.isItemStackDamageable()) {
+                    return;
+                }
             } else {
                 heldItem.damageItem(1, player);
             }

--- a/src/main/java/com/direwolf20/buildinggadgets/items/ExchangerTool.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/items/ExchangerTool.java
@@ -308,7 +308,9 @@ public class ExchangerTool extends GenericGadget {
             }
         } else {
             if (tool.getItemDamage() >= tool.getMaxDamage()) {
-                return false;
+                if (tool.isItemStackDamageable()) {
+                    return false;
+                }
             } else {
                 tool.damageItem(2, player);
             }

--- a/src/main/java/com/direwolf20/buildinggadgets/items/ExchangerTool.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/items/ExchangerTool.java
@@ -303,7 +303,7 @@ public class ExchangerTool extends GenericGadget {
             return false;
         }
         if (Config.poweredByFE) {
-            if (!useEnergy(tool, Config.energyCostBuilder, player)) {
+            if (!useEnergy(tool, Config.energyCostExchanger, player)) {
                 return false;
             }
         } else {

--- a/src/main/java/com/direwolf20/buildinggadgets/tools/ToolRenders.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/tools/ToolRenders.java
@@ -88,7 +88,7 @@ public class ToolRenders {
                 } else {
                     hasEnergy = stack.getMaxDamage() - stack.getItemDamage();
                 }
-                if (player.capabilities.isCreativeMode) {
+                if (player.capabilities.isCreativeMode || (!Config.poweredByFE && !stack.isItemStackDamageable())) {
                     hasEnergy = 1000000;
                 }
                 //Prepare the block rendering
@@ -214,7 +214,7 @@ public class ToolRenders {
                 } else {
                     hasEnergy = stack.getMaxDamage() - stack.getItemDamage();
                 }
-                if (player.capabilities.isCreativeMode) {
+                if (player.capabilities.isCreativeMode || (!Config.poweredByFE && !stack.isItemStackDamageable())) {
                     hasEnergy = 1000000;
                 }
                 //Prepare the block rendering


### PR DESCRIPTION
Currently, setting a tool's damage config to <= 0 makes the tool unusable when the poweredByFE config is false. This means that the copy/paste tool is always unusable without power, since it doesn't have a durability config.  I understand that it's a WIP, and may eventually have durability, but even so, it's nice for all tools to be configured to not require power and not take damage. I also fixed a bug where the exchanger was using the builder's energy requirement config.