### PR TITLE
Remove usage of ITileEntityProvider

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/blocks/ConstructionBlock.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/blocks/ConstructionBlock.java
@@ -6,7 +6,6 @@ import com.direwolf20.buildinggadgets.blocks.Models.ConstructionBakedModel;
 import com.direwolf20.buildinggadgets.blocks.Models.ConstructionID;
 import com.direwolf20.buildinggadgets.blocks.Models.ConstructionProperty;
 import net.minecraft.block.Block;
-import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyBool;
@@ -40,7 +39,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Random;
 
-public class ConstructionBlock extends Block implements ITileEntityProvider {
+public class ConstructionBlock extends Block {
     public static final ConstructionProperty FACADEID = new ConstructionProperty("facadeid");
     public static final PropertyBool BRIGHT = PropertyBool.create("bright");
 
@@ -76,7 +75,12 @@ public class ConstructionBlock extends Block implements ITileEntityProvider {
     }
 
     @Override
-    public TileEntity createNewTileEntity(World worldIn, int meta) {
+    public boolean hasTileEntity(IBlockState state) {
+        return true;
+    }
+
+    @Override
+    public TileEntity createTileEntity(World worldIn, IBlockState state) {
         return new ConstructionBlockTileEntity();
     }
 

--- a/src/main/java/com/direwolf20/buildinggadgets/blocks/templatemanager/TemplateManager.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/blocks/templatemanager/TemplateManager.java
@@ -2,7 +2,6 @@ package com.direwolf20.buildinggadgets.blocks.templatemanager;
 
 import com.direwolf20.buildinggadgets.BuildingGadgets;
 import net.minecraft.block.Block;
-import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
@@ -17,7 +16,7 @@ import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class TemplateManager extends Block implements ITileEntityProvider {
+public class TemplateManager extends Block {
     public static final int GUI_ID = 1;
 
     public TemplateManager() {
@@ -33,7 +32,12 @@ public class TemplateManager extends Block implements ITileEntityProvider {
     }
 
     @Override
-    public TileEntity createNewTileEntity(World worldIn, int meta) {
+    public boolean hasTileEntity(IBlockState state) {
+        return true;
+    }
+
+    @Override
+    public TileEntity createTileEntity(World worldin, IBlockState state) {
         return new TemplateManagerTileEntity();
     }
 


### PR DESCRIPTION
This pull request replaces the use of ITileEntityProvider#createNewTileEntity() with the replacement-methods in the Block class, namly Block#hasTileEntity and Block#createTileEntity.

The reason for this is, that Forge recommends not using ITileEntityProvider as seen in [Problematic Code#4 ](http://www.minecraftforge.net/forum/topic/61757-common-issues-and-recommendations/?tab=comments#comment-289566)

FYI: I wrote about this in the Livestreamchat on Sunday