### PR TITLE
Extended Max Energy for Destruction Tool

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/Config.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/Config.java
@@ -15,6 +15,7 @@ public class Config {
     public static int energyCostExchanger = 100;
     public static int energyCostDestruction = 200;
     public static int energyMax = 500000;
+    public static int energyMaxDestruction = 1000000;
     public static boolean poweredByFE = true;
     public static int durabilityBuilder = 500;
     public static int durabilityExchanger = 500;
@@ -48,6 +49,7 @@ public class Config {
         energyCostExchanger = cfg.getInt("energyCostExchanger", CATEGORY_GENERAL, energyCostExchanger, 0, 100000, "The energy cost of the Exchanger per block");
         energyCostDestruction = cfg.getInt("energyCostDestruction", CATEGORY_GENERAL, energyCostDestruction, 0, 100000, "The energy cost of the Destruction Gadget per block");
         energyMax = cfg.getInt("energyMax", CATEGORY_GENERAL, energyMax, 0, Integer.MAX_VALUE, "The max energy of the Builder & Exchanger");
+        energyMaxDestruction = cfg.getInt("energyMaxDestruction", CATEGORY_GENERAL, energyMaxDestruction, 0, Integer.MAX_VALUE, "The max energy of the Destruction Gadget");
         poweredByFE = cfg.getBoolean("poweredByFE", CATEGORY_GENERAL, poweredByFE, "Set to true for Forge Energy Support, set to False for vanilla Item Damage");
         durabilityBuilder = cfg.getInt("durabilityBuilder", CATEGORY_GENERAL, durabilityBuilder, 0, 100000, "The max durability of the Builder (Ignored if powered by FE)");
         durabilityExchanger = cfg.getInt("durabilityExchanger", CATEGORY_GENERAL, durabilityExchanger, 0, 100000, "The max durability of the Exchanger (Ignored if powered by FE)");

--- a/src/main/java/com/direwolf20/buildinggadgets/items/DestructionTool.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/items/DestructionTool.java
@@ -52,8 +52,11 @@ public class DestructionTool extends GenericGadget {
         setUnlocalizedName(BuildingGadgets.MODID + ".destructiontool");     // Used for localization (en_US.lang)
         setMaxStackSize(1);
         setCreativeTab(CreativeTabs.TOOLS);
+    }
 
-        this.setEnergyMax( Config.energyMaxDestruction );
+    @Override
+    public int getEnergyMax() {
+        return Config.energyMaxDestruction;
     }
 
     @Override

--- a/src/main/java/com/direwolf20/buildinggadgets/items/DestructionTool.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/items/DestructionTool.java
@@ -52,6 +52,8 @@ public class DestructionTool extends GenericGadget {
         setUnlocalizedName(BuildingGadgets.MODID + ".destructiontool");     // Used for localization (en_US.lang)
         setMaxStackSize(1);
         setCreativeTab(CreativeTabs.TOOLS);
+
+        this.setEnergyMax( Config.energyMaxDestruction );
     }
 
     @Override

--- a/src/main/java/com/direwolf20/buildinggadgets/items/GenericGadget.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/items/GenericGadget.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
 
 public class GenericGadget extends Item {
 
-    public int energyMax;
+    private int energyMax;
 
     public GenericGadget() {
         this.energyMax = Config.energyMax;
@@ -41,7 +41,7 @@ public class GenericGadget extends Item {
     @Nullable
     public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound tag) {
         if (Config.poweredByFE) {
-            return new CapabilityProviderEnergy(stack, this.energyMax);
+            return new CapabilityProviderEnergy(stack, this.getEnergyMax());
         }
         return null;
     }

--- a/src/main/java/com/direwolf20/buildinggadgets/items/GenericGadget.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/items/GenericGadget.java
@@ -18,6 +18,19 @@ import javax.annotation.Nullable;
 
 public class GenericGadget extends Item {
 
+    public int energyMax;
+
+    public GenericGadget() {
+        this.energyMax = Config.energyMax;
+    }
+
+    public int getEnergyMax() {
+        return energyMax;
+    }
+
+    public void setEnergyMax(int energyMax) {
+        this.energyMax = energyMax;
+    }
 
     @SideOnly(Side.CLIENT)
     public void initModel() {
@@ -28,7 +41,7 @@ public class GenericGadget extends Item {
     @Nullable
     public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound tag) {
         if (Config.poweredByFE) {
-            return new CapabilityProviderEnergy(stack, Config.energyMax);
+            return new CapabilityProviderEnergy(stack, this.energyMax);
         }
         return null;
     }

--- a/src/main/java/com/direwolf20/buildinggadgets/items/GenericGadget.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/items/GenericGadget.java
@@ -18,18 +18,8 @@ import javax.annotation.Nullable;
 
 public class GenericGadget extends Item {
 
-    private int energyMax;
-
-    public GenericGadget() {
-        this.energyMax = Config.energyMax;
-    }
-
     public int getEnergyMax() {
-        return energyMax;
-    }
-
-    public void setEnergyMax(int energyMax) {
-        this.energyMax = energyMax;
+        return Config.energyMax;
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
- Extended the max energry for the destruction tool. 
- Added support for seperate `energyMax` per item tool but by default use the `Config.energyMax`.
  - Added 2 new methods to GernericGadget `setEnergyMax` & `getEnergyMax`

Added a new config line for `energyMaxDestruction` and defined default at `1,000,000` (1M)

Resolves #123 