### PR TITLE
Allow rebinding tooltip key. Fix for #177.

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/client/KeyBindings.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/client/KeyBindings.java
@@ -19,16 +19,19 @@ public class KeyBindings {
     public static KeyBinding rangeChange;
     public static KeyBinding undoKey;
     public static KeyBinding anchorKey;
+    public static KeyBinding tooltipKey;
 
     public static void init() {
         modeSwitch = new KeyBinding("key.modeSwitch", CONFLICT_CONTEXT_GADGET, Keyboard.KEY_G, "key.categories.buildingGadgets");
         rangeChange = new KeyBinding("key.rangeChange", CONFLICT_CONTEXT_GADGET, Keyboard.KEY_R, "key.categories.buildingGadgets");
         undoKey = new KeyBinding("key.undoKey", CONFLICT_CONTEXT_GADGET, Keyboard.KEY_U, "key.categories.buildingGadgets");
         anchorKey = new KeyBinding("key.anchorKey", CONFLICT_CONTEXT_GADGET, Keyboard.KEY_H, "key.categories.buildingGadgets");
+        tooltipKey = new KeyBinding("key.tooltip", KeyConflictContext.GUI, Keyboard.KEY_LSHIFT, "key.categories.buildingGadgets");
         ClientRegistry.registerKeyBinding(modeSwitch);
         ClientRegistry.registerKeyBinding(rangeChange);
         ClientRegistry.registerKeyBinding(undoKey);
         ClientRegistry.registerKeyBinding(anchorKey);
+        ClientRegistry.registerKeyBinding(tooltipKey);
     }
 
     public static class KeyConflictContextGadget implements IKeyConflictContext

--- a/src/main/java/com/direwolf20/buildinggadgets/client/events/EventTooltip.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/client/events/EventTooltip.java
@@ -7,6 +7,7 @@ package com.direwolf20.buildinggadgets.client.events;
 
 import com.direwolf20.buildinggadgets.common.items.ModItems;
 import com.direwolf20.buildinggadgets.common.items.gadgets.GadgetCopyPaste;
+import com.direwolf20.buildinggadgets.client.KeyBindings;
 import com.direwolf20.buildinggadgets.common.items.ITemplate;
 import com.direwolf20.buildinggadgets.common.tools.BlockMap;
 import com.direwolf20.buildinggadgets.common.tools.InventoryManipulation;
@@ -14,7 +15,6 @@ import com.direwolf20.buildinggadgets.common.tools.PasteToolBufferBuilder;
 import com.direwolf20.buildinggadgets.common.tools.UniqueItem;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderItem;
 import net.minecraft.init.Items;
@@ -23,11 +23,14 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.client.event.RenderTooltipEvent;
+import net.minecraftforge.client.settings.KeyConflictContext;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
+import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
 import java.util.*;
@@ -37,9 +40,16 @@ public class EventTooltip {
 
     private static final int STACKS_PER_LINE = 8;
 
+    private static boolean tooltipKeyIsDown() {
+        int keyCode = KeyBindings.tooltipKey.getKeyCode();
+        return keyCode != 0
+                && KeyBindings.tooltipKey.getKeyModifier().isActive(KeyBindings.tooltipKey.getKeyConflictContext())
+                && Keyboard.isKeyDown(keyCode);
+    }
+
     @SideOnly(Side.CLIENT)
     private static void tooltipIfShift(@SuppressWarnings("unused") List<String> tooltip, Runnable r) {
-        if (GuiScreen.isShiftKeyDown())
+        if (tooltipKeyIsDown())
             r.run();
         //else addToTooltip(tooltip, "arl.misc.shiftForInfo");
     }
@@ -96,7 +106,7 @@ public class EventTooltip {
     public static void onDrawTooltip(RenderTooltipEvent.PostText event) {
         //This method will draw items on the tooltip
         ItemStack stack = event.getStack();
-        if ((stack.getItem() instanceof ITemplate) && GuiScreen.isShiftKeyDown()) {
+        if ((stack.getItem() instanceof ITemplate) && tooltipKeyIsDown()) {
             int totalMissing = 0;
             Map<UniqueItem, Integer> itemCountMap = ((ITemplate) stack.getItem()).getItemCountMap(stack);
 

--- a/src/main/resources/assets/buildinggadgets/lang/en_us.lang
+++ b/src/main/resources/assets/buildinggadgets/lang/en_us.lang
@@ -40,6 +40,7 @@ key.categories.buildingGadgets=Building Gadgets
 key.modeSwitch=Mode Switch
 key.rangeChange=Range
 key.undoKey=Undo/Fuzzy
+key.tooltip=Tooltip Modifier
 
 #tooltip: 
 tooltip.constructionblockpowder.helptext=Place next to water


### PR DESCRIPTION
I originally created an issue centered around the issue that Building Gadgets and Thaumcraft clashes in modifying tooltips of the Copy Paste Gadget.

Here is a possible fix that simply allows the user to rebind the key held to modify the tooltip, so that Thaumcraft can use Left Shift, and the user can use another for Building Gadgets.

Not the most ideal fix, but from what I've seen there is no standard to work with when modifying tooltips so the clash is difficult to fix >.<
Signed-off-by: FenixFyreX <fenixfyrex@gmail.com>