### PR TITLE
Prevent blocks from rending over Thaumcraft Aspects in tooltips.

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/client/events/EventTooltip.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/client/events/EventTooltip.java
@@ -25,6 +25,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.client.event.RenderTooltipEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -44,7 +45,7 @@ public class EventTooltip {
         //else addToTooltip(tooltip, "arl.misc.shiftForInfo");
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGH)
     public static void onMakeTooltip(ItemTooltipEvent event) {
         //This method extends the tooltip box size to fit the item's we will render in onDrawTooltip
         Minecraft mc = Minecraft.getMinecraft();

--- a/src/main/java/com/direwolf20/buildinggadgets/client/events/EventTooltip.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/client/events/EventTooltip.java
@@ -23,9 +23,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.client.event.RenderTooltipEvent;
-import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
-import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -45,19 +43,14 @@ public class EventTooltip {
         //else addToTooltip(tooltip, "arl.misc.shiftForInfo");
     }
 
-    @SubscribeEvent(priority = EventPriority.HIGH)
-    public static void onMakeTooltip(ItemTooltipEvent event) {
+    public static void addTemplatePadding(ItemStack stack, List<String> tooltip) {
         //This method extends the tooltip box size to fit the item's we will render in onDrawTooltip
         Minecraft mc = Minecraft.getMinecraft();
-        ItemStack stack = event.getItemStack();
         if (stack.getItem() instanceof ITemplate) {
             ITemplate template = (ITemplate) stack.getItem();
             String UUID = template.getUUID(stack);
-            if (UUID == null) {
-                return;
-            }
+            if (UUID == null) return;
 
-            List<String> tooltip = event.getToolTip();
             Map<UniqueItem, Integer> itemCountMap = template.getItemCountMap(stack);
 
             Map<ItemStack, Integer> itemStackCount = new HashMap<ItemStack, Integer>();
@@ -71,9 +64,8 @@ public class EventTooltip {
             //Look through all the ItemStacks and draw each one in the specified X/Y position
             for (Map.Entry<ItemStack, Integer> entry : list) {
                 int hasAmt = InventoryManipulation.countItem(entry.getKey(), Minecraft.getMinecraft().player);
-                if (hasAmt < entry.getValue()) {
+                if (hasAmt < entry.getValue())
                     totalMissing = totalMissing + Math.abs(entry.getValue() - hasAmt);
-                }
             }
 
             int count = (totalMissing > 0) ? itemCountMap.size() + 1 : itemStackCount.size();

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/Template.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/Template.java
@@ -1,5 +1,6 @@
 package com.direwolf20.buildinggadgets.common.items;
 
+import com.direwolf20.buildinggadgets.client.events.EventTooltip;
 import com.direwolf20.buildinggadgets.common.BuildingGadgets;
 import com.direwolf20.buildinggadgets.common.tools.GadgetUtils;
 import com.direwolf20.buildinggadgets.common.tools.WorldSave;
@@ -65,6 +66,7 @@ public class Template extends Item implements ITemplate {
         //Add tool information to the tooltip
         super.addInformation(stack, world, list, b);
         list.add(TextFormatting.AQUA + I18n.format("tooltip.template.name") + ": " + getName(stack));
+        EventTooltip.addTemplatePadding(stack, list);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetCopyPaste.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetCopyPaste.java
@@ -1,5 +1,6 @@
 package com.direwolf20.buildinggadgets.common.items.gadgets;
 
+import com.direwolf20.buildinggadgets.client.events.EventTooltip;
 import com.direwolf20.buildinggadgets.client.gui.GuiProxy;
 import com.direwolf20.buildinggadgets.common.BuildingGadgets;
 import com.direwolf20.buildinggadgets.common.Config;
@@ -236,6 +237,7 @@ public class GadgetCopyPaste extends GadgetGeneric implements ITemplate {
             IEnergyStorage energy = CapabilityProviderEnergy.getCap(stack);
             list.add(TextFormatting.WHITE + I18n.format("tooltip.gadget.energy") + ": " + withSuffix(energy.getEnergyStored()) + "/" + withSuffix(energy.getMaxEnergyStored()));
         }
+        EventTooltip.addTemplatePadding(stack, list);
     }
 
     public void setMode(EntityPlayer player, ItemStack heldItem, int modeInt) {


### PR DESCRIPTION
The Enigmatica 2: Expert modpack contains Botania. Botania's depenency on Thaumcraft causes Thaumcraft  to load before Building Gadgets. TC renders Aspects by first adding spaces in `ItemTooltipEvent`, then searching up from the bottom line in `RenderTooltipEvent.PostBackground`, stopping on the first line containing a stretch of spaces. BG, however, renders blocks by first adding color characters padded with spaces in `ItemTooltipEvent`, then searching down from the top line in `RenderTooltipEvent.PostText`, stopping on the first line equaling the recognition characters after formatting out all spaces from each line.

This means that as long as `ItemTooltipEvent` is called in BG before it is in TC, things render fine; but if the order is reversed, BG renders on the bottom (where the recognition chars are), but TC stops on the padding added to the bottom-most line by BC, rendering the Aspects in the same place.

~~By increasing the priority of `ItemTooltipEvent` in BG, any mod that adds spaces and/or unique recognition chars to the bottom a tooltip in `ItemTooltipEvent` at normal priority or lower will do so under BG's recognition chars, fixing #177.~~

By moving the addition of padding and recognition chars from `ItemTooltipEvent` to `Item#addInformation`, template tooltip block rendering is independent of event-call/mod-load order, fixing #177.