### PR TITLE
Fixes #169, double use of all gadgets.

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetBuilding.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetBuilding.java
@@ -115,23 +115,6 @@ public class GadgetBuilding extends GadgetGeneric {
     }
 
     @Override
-    public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
-        //On item use, if sneaking, select the block clicked on, else build -- This is called when a block in clicked on
-        if (world.isRemote)
-            return EnumActionResult.FAIL;
-
-        ItemStack stack = player.getHeldItem(hand);
-        player.setActiveHand(hand);
-
-        if (player.isSneaking())
-            selectBlock(stack, player);
-        else
-            this.build(player, stack);
-
-        return EnumActionResult.SUCCESS;
-    }
-
-    @Override
     public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
         //On item use, if sneaking, select the block clicked on, else build -- This is called when you right click a tool NOT on a block.
         ItemStack itemstack = player.getHeldItem(hand);

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetCopyPaste.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetCopyPaste.java
@@ -246,46 +246,6 @@ public class GadgetCopyPaste extends GadgetGeneric implements ITemplate {
     }
 
     @Override
-    public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
-        ItemStack stack = player.getHeldItem(hand);
-        player.setActiveHand(hand);
-        if (!world.isRemote) {
-            if (getToolMode(stack) == ToolMode.Copy) {
-                if (player.isSneaking()) {
-                    if (getStartPos(stack) != null) {
-                        copyBlocks(stack, player, world, getStartPos(stack), pos);
-                    } else {
-                        setEndPos(stack, pos);
-                    }
-                } else {
-                    //setStartPos(stack, pos);
-                    if (getEndPos(stack) != null) {
-                        copyBlocks(stack, player, world, pos, getEndPos(stack));
-                    } else {
-                        setStartPos(stack, pos);
-                    }
-                }
-
-            } else if (getToolMode(stack) == ToolMode.Paste) {
-                if (!player.isSneaking()) {
-                    buildBlockMap(world, pos, stack, player);
-                }
-            }
-            NBTTagCompound tagCompound = stack.getTagCompound();
-            ByteBuf buf = Unpooled.buffer(16);
-            ByteBufUtils.writeTag(buf, tagCompound);
-            //System.out.println(buf.readableBytes());
-        } else {
-            if (player.isSneaking() && getToolMode(stack) == ToolMode.Paste) {
-                player.openGui(BuildingGadgets.instance, GuiProxy.PasteID, world, hand.ordinal(), 0, 0);
-                return EnumActionResult.SUCCESS;
-            }
-        }
-
-        return EnumActionResult.SUCCESS;
-    }
-
-    @Override
     public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
         ItemStack stack = player.getHeldItem(hand);
         player.setActiveHand(hand);

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetDestruction.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetDestruction.java
@@ -216,29 +216,6 @@ public class GadgetDestruction extends GadgetGeneric {
     }
 
     @Override
-    public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
-        ItemStack stack = player.getHeldItem(hand);
-        player.setActiveHand(hand);
-        if (!world.isRemote) {
-            if (!player.isSneaking()) {
-                clearArea(world, pos, side, player, stack);
-                if (getAnchor(stack) != null) {
-                    setAnchor(stack, null);
-                    setAnchorSide(stack, null);
-                    player.sendStatusMessage(new TextComponentString(TextFormatting.AQUA + new TextComponentTranslation("message.gadget.anchorremove").getUnformattedComponentText()), true);
-                }
-            }
-        } else {
-            if (player.isSneaking()) {
-                player.openGui(BuildingGadgets.instance, GuiProxy.DestructionID, world, hand.ordinal(), 0, 0);
-                return EnumActionResult.SUCCESS;
-            }
-        }
-
-        return EnumActionResult.SUCCESS;
-    }
-
-    @Override
     public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
         ItemStack stack = player.getHeldItem(hand);
         player.setActiveHand(hand);

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetExchanger.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetExchanger.java
@@ -142,21 +142,6 @@ public class GadgetExchanger extends GadgetGeneric {
         }
     }
 
-
-    @Override
-    public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
-        ItemStack stack = player.getHeldItem(hand);
-        player.setActiveHand(hand);
-        if (!world.isRemote) {
-            if (player.isSneaking()) {
-                selectBlock(stack, player);
-            } else {
-                exchange(player, stack);
-            }
-        }
-        return EnumActionResult.SUCCESS;
-    }
-
     @Override
     public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
         ItemStack itemstack = player.getHeldItem(hand);


### PR DESCRIPTION
This fixes the issue of the building gadget (and silently all other gadgets) firing twice if the player is in block place range of the block they are looking at. The `Item#onItemUse` method isn't necessary, and is basically duplicate code of `Item#onItemRightClick` which handles looking at a specific block anyway.
Signed-off-by: FenixFyreX <fenixfyrex@gmail.com>