### PR TITLE
[WIP] Implement schematic support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ repositories {
 dependencies {
     deobfCompile "team.chisel.ctm:CTM:MC${minecraft_version}-${ctm_version}:api"
     runtime "team.chisel.ctm:CTM:MC${minecraft_version}-${ctm_version}"
+    testCompile "junit:junit:4.+"
+    testCompile "org.hamcrest:hamcrest:2.+"
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..
     //compile "some.group:artifact:version:classifier"

--- a/src/main/java/com/direwolf20/buildinggadgets/common/BuildingGadgets.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/BuildingGadgets.java
@@ -5,6 +5,7 @@ import com.direwolf20.buildinggadgets.common.commands.FindBlockMapsCommand;
 import com.direwolf20.buildinggadgets.common.events.AnvilRepairHandler;
 import com.direwolf20.buildinggadgets.common.items.ModItems;
 import com.direwolf20.buildinggadgets.common.proxy.CommonProxy;
+import com.direwolf20.buildinggadgets.common.schematics.SchematicResourceProvider;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextComponentTranslation;
@@ -40,10 +41,12 @@ public class BuildingGadgets {
     public static BuildingGadgets instance;
 
     public static Logger logger;
+    private SchematicResourceProvider schematicProvider;
 
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
         logger = event.getModLog();
+        schematicProvider = SchematicResourceProvider.createInstance(event.getModConfigurationDirectory());
         proxy.preInit(event);
         if (!Config.poweredByFE) {
             MinecraftForge.EVENT_BUS.register(new AnvilRepairHandler());
@@ -64,5 +67,10 @@ public class BuildingGadgets {
     public void serverLoad(FMLServerStartingEvent event) {
         event.registerServerCommand(new FindBlockMapsCommand());
         event.registerServerCommand(new DeleteBlockMapsCommand());
+    }
+
+    public SchematicResourceProvider getSchematicProvider() {
+        if (schematicProvider == null) throw new IllegalStateException("SchematicProvider accessed before it could be properly created. The Schematic provider is only valid after Initilisition has passed!");
+        return schematicProvider;
     }
 }

--- a/src/main/java/com/direwolf20/buildinggadgets/common/schematics/ISchematic.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/schematics/ISchematic.java
@@ -1,0 +1,23 @@
+package com.direwolf20.buildinggadgets.common.schematics;
+
+import net.minecraft.block.Block;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+
+import java.util.List;
+
+public interface ISchematic{
+    public int getWidth();
+
+    public int getHeight();
+
+    public int getLength();
+
+    public List<Block> getBlocks();
+
+    public default Block getBlock(BlockPos pos) {
+        return getBlock(pos.getX(),pos.getY(),pos.getZ());
+    }
+
+    public Block getBlock(int x, int y, int z);
+}

--- a/src/main/java/com/direwolf20/buildinggadgets/common/schematics/SchematicLoader.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/schematics/SchematicLoader.java
@@ -1,0 +1,44 @@
+package com.direwolf20.buildinggadgets.common.schematics;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+public enum SchematicLoader {
+    MC_STRUCTURE {
+        @Override
+        public ISchematic loadFromNBT(NBTTagCompound compound) {
+            return null;
+        }
+
+        @Override
+        public NBTTagCompound writeToNBT(ISchematic schematic) {
+            return null;
+        }
+    },
+    MC_ALPHA {
+        @Override
+        public ISchematic loadFromNBT(NBTTagCompound compound) {
+            return null;
+        }
+
+        @Override
+        public NBTTagCompound writeToNBT(ISchematic schematic) {
+            return null;
+        }
+    },
+    //really old format - not truly needed, but for the sake of completeness might as well put this here
+    MC_CLASSIC {
+        @Override
+        public ISchematic loadFromNBT(NBTTagCompound compound) {
+            return null;
+        }
+
+        @Override
+        public NBTTagCompound writeToNBT(ISchematic schematic) {
+            return null;
+        }
+    };
+
+    public abstract ISchematic loadFromNBT(NBTTagCompound compound);
+
+    public abstract NBTTagCompound writeToNBT(ISchematic schematic);
+}

--- a/src/main/java/com/direwolf20/buildinggadgets/common/schematics/SchematicResourceProvider.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/schematics/SchematicResourceProvider.java
@@ -1,0 +1,27 @@
+package com.direwolf20.buildinggadgets.common.schematics;
+
+import net.minecraft.util.ResourceLocation;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SchematicResourceProvider {
+    public static SchematicResourceProvider createInstance(File modConfigDir) {
+        return new SchematicResourceProvider(modConfigDir.toPath());
+    }
+
+    private static final String SCHEMATIC_DIR = "schematics/";
+    private Map<ResourceLocation, ISchematic> schematics;
+    private Path schematicSourceDir;
+
+    private SchematicResourceProvider(Path modConfigDir) {
+        schematics = new HashMap<>();
+        schematicSourceDir = modConfigDir.resolve(SCHEMATIC_DIR);
+    }
+
+    public void reload() {
+
+    }
+}


### PR DESCRIPTION
The main reason I already opened this is, that people can already discuss what should actually be supported here (#180 didn't provide much discussion on how this should be done).

My current idea is, that people would be able to load schematics from config/buildinggadgets/schematics, merging server and client schematics at runtime. Client Schematic should override server provided schematics in my opinion. Also a way may be provided for people to save schematics on their client.

In order to access these schematics I'd create a new Block (SchematicManager?) which would allow to create Templates from schematic Files. 