### PR TITLE
Fix too large Templates being copied to Clipboard

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/common/blocks/templatemanager/TemplateManagerCommands.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/blocks/templatemanager/TemplateManagerCommands.java
@@ -249,6 +249,6 @@ public class TemplateManagerCommands {
     }
 
     private static void pasteIsTooLarge() {
-        Minecraft.getMinecraft().player.sendStatusMessage(new TextComponentString(TextFormatting.AQUA + new TextComponentTranslation("message.gadget.pastetoobig").getUnformattedComponentText()), false);
+        Minecraft.getMinecraft().player.sendStatusMessage(new TextComponentString(TextFormatting.RED + new TextComponentTranslation("message.gadget.pastetoobig").getUnformattedComponentText()), false);
     }
 }

--- a/src/main/java/com/direwolf20/buildinggadgets/common/blocks/templatemanager/TemplateManagerCommands.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/blocks/templatemanager/TemplateManagerCommands.java
@@ -1,5 +1,6 @@
 package com.direwolf20.buildinggadgets.common.blocks.templatemanager;
 
+import com.direwolf20.buildinggadgets.common.BuildingGadgets;
 import com.direwolf20.buildinggadgets.common.items.ITemplate;
 import com.direwolf20.buildinggadgets.common.items.ModItems;
 import com.direwolf20.buildinggadgets.common.items.Template;
@@ -25,6 +26,7 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -231,9 +233,22 @@ public class TemplateManagerCommands {
             //Map<UniqueItem, Integer> tagMap = GadgetCopyPaste.getItemCountMap(itemStack0);
             //NBTTagList tagList = GadgetUtils.itemCountToNBT(tagMap);
             //newCompound.setTag("itemcountmap", tagList);
-            String jsonTag = newCompound.toString();
-            setClipboardString(jsonTag);
-            Minecraft.getMinecraft().player.sendStatusMessage(new TextComponentString(TextFormatting.AQUA + new TextComponentTranslation("message.gadget.copysuccess").getUnformattedComponentText()), false);
+            try {
+                if (GadgetUtils.isSizeValid(newCompound,tagCompound.getString("name"))) {
+                    String jsonTag = newCompound.toString();
+                    setClipboardString(jsonTag);
+                    Minecraft.getMinecraft().player.sendStatusMessage(new TextComponentString(TextFormatting.AQUA + new TextComponentTranslation("message.gadget.copysuccess").getUnformattedComponentText()), false);
+                } else {
+                    pasteIsTooLarge();
+                }
+            } catch (IOException e) {
+                BuildingGadgets.logger.error("Failed to evaluate template network size. Template will be considered too large.",e);
+                pasteIsTooLarge();
+            }
         }
+    }
+
+    private static void pasteIsTooLarge() {
+        Minecraft.getMinecraft().player.sendStatusMessage(new TextComponentString(TextFormatting.AQUA + new TextComponentTranslation("message.gadget.pastetoobig").getUnformattedComponentText()), false);
     }
 }

--- a/src/main/java/com/direwolf20/buildinggadgets/common/blocks/templatemanager/TemplateManagerGUI.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/blocks/templatemanager/TemplateManagerGUI.java
@@ -15,6 +15,7 @@ import com.direwolf20.buildinggadgets.common.network.PacketHandler;
 import com.direwolf20.buildinggadgets.common.network.PacketTemplateManagerLoad;
 import com.direwolf20.buildinggadgets.common.network.PacketTemplateManagerPaste;
 import com.direwolf20.buildinggadgets.common.network.PacketTemplateManagerSave;
+import com.direwolf20.buildinggadgets.common.tools.GadgetUtils;
 import com.direwolf20.buildinggadgets.common.tools.PasteToolBufferBuilder;
 import com.direwolf20.buildinggadgets.common.tools.ToolDireBuffer;
 import net.minecraft.client.Minecraft;
@@ -306,17 +307,9 @@ public class TemplateManagerGUI extends GuiContainer {
             //System.out.println(CBString);
             try {
                 NBTTagCompound tagCompound = JsonToNBT.getTagFromJson(CBString);
-                //BlockMapIntState MapIntState = GadgetCopyPaste.getBlockMapIntState(tagCompound);
-                int[] stateArray = tagCompound.getIntArray("stateIntArray");
-                //int[] posArray = tagCompound.getIntArray("posIntArray");
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                CompressedStreamTools.writeCompressed(tagCompound, baos);
-                //ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-                //NBTTagCompound newTag = CompressedStreamTools.readCompressed(bais);
-                //System.out.println("BAOS Size: " + baos.size());
 
                 //Anything larger than below is likely to overflow the max packet size, crashing your client.
-                if (stateArray.length <= 12000 && baos.size() < 31000) {
+                if (GadgetUtils.isSizeValid(tagCompound,nameField.getText())) {
                     PacketHandler.INSTANCE.sendToServer(new PacketTemplateManagerPaste(tagCompound, te.getPos(), nameField.getText()));
                     Minecraft.getMinecraft().player.sendStatusMessage(new TextComponentString(TextFormatting.AQUA + new TextComponentTranslation("message.gadget.pastesuccess").getUnformattedComponentText()), false);
                 } else {

--- a/src/main/java/com/direwolf20/buildinggadgets/common/tools/GadgetUtils.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/tools/GadgetUtils.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTUtil;
@@ -29,6 +30,8 @@ import net.minecraftforge.items.IItemHandler;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,6 +43,14 @@ public class GadgetUtils {
 
     private static String getStackErrorText(ItemStack stack) {
         return "the following stack: [" + stack + "]";
+    }
+
+    public static boolean isSizeValid(@Nonnull NBTTagCompound compound, @Nullable String name) throws IOException{
+        NBTTagCompound withText = name!=null && !name.isEmpty()?compound.copy():compound;
+        if (name!=null && !name.isEmpty()) withText.setString("name",name);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CompressedStreamTools.writeCompressed(withText, baos);
+        return baos.size()<Short.MAX_VALUE-200;
     }
 
     @Nonnull


### PR DESCRIPTION
Fix #205 by performing the Template-Size-Check before copying it into Clipboard too.

I increased the threshold to Short.MAX_VALUE-200 as this is still quite a bit away from the Short.MAX_VALUE C2S Packet Border and should cover all bytes Forge might be sending. Additionally I removed the 1200 states check, as that is completely unnecessary, because we are already checking the size of it - it doesn't make a difference if it consists of thousands of blocks, or thousands of states, as long as it's below the Packet Limit...!