### PR TITLE
Fix potential, though unlikely, crash when changing the poweredByFE setting at runtime

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/common/BuildingGadgets.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/BuildingGadgets.java
@@ -2,14 +2,11 @@ package com.direwolf20.buildinggadgets.common;
 
 import com.direwolf20.buildinggadgets.common.commands.DeleteBlockMapsCommand;
 import com.direwolf20.buildinggadgets.common.commands.FindBlockMapsCommand;
-import com.direwolf20.buildinggadgets.common.config.SyncedConfig;
-import com.direwolf20.buildinggadgets.common.events.AnvilRepairHandler;
 import com.direwolf20.buildinggadgets.common.items.ModItems;
 import com.direwolf20.buildinggadgets.common.proxy.CommonProxy;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextComponentTranslation;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
@@ -46,7 +43,6 @@ public class BuildingGadgets {
     public void preInit(FMLPreInitializationEvent event) {
         logger = event.getModLog();
         proxy.preInit(event);
-        MinecraftForge.EVENT_BUS.register(new AnvilRepairHandler());
     }
 
     @Mod.EventHandler

--- a/src/main/java/com/direwolf20/buildinggadgets/common/BuildingGadgets.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/BuildingGadgets.java
@@ -46,9 +46,7 @@ public class BuildingGadgets {
     public void preInit(FMLPreInitializationEvent event) {
         logger = event.getModLog();
         proxy.preInit(event);
-        if (!SyncedConfig.poweredByFE) {
-            MinecraftForge.EVENT_BUS.register(new AnvilRepairHandler());
-        }
+        MinecraftForge.EVENT_BUS.register(new AnvilRepairHandler());
     }
 
     @Mod.EventHandler

--- a/src/main/java/com/direwolf20/buildinggadgets/common/blocks/templatemanager/TemplateManagerCommands.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/blocks/templatemanager/TemplateManagerCommands.java
@@ -1,6 +1,5 @@
 package com.direwolf20.buildinggadgets.common.blocks.templatemanager;
 
-import com.direwolf20.buildinggadgets.common.BuildingGadgets;
 import com.direwolf20.buildinggadgets.common.items.ITemplate;
 import com.direwolf20.buildinggadgets.common.items.ModItems;
 import com.direwolf20.buildinggadgets.common.items.Template;
@@ -26,7 +25,6 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -233,22 +231,9 @@ public class TemplateManagerCommands {
             //Map<UniqueItem, Integer> tagMap = GadgetCopyPaste.getItemCountMap(itemStack0);
             //NBTTagList tagList = GadgetUtils.itemCountToNBT(tagMap);
             //newCompound.setTag("itemcountmap", tagList);
-            try {
-                if (GadgetUtils.isSizeValid(newCompound,tagCompound.getString("name"))) {
-                    String jsonTag = newCompound.toString();
-                    setClipboardString(jsonTag);
-                    Minecraft.getMinecraft().player.sendStatusMessage(new TextComponentString(TextFormatting.AQUA + new TextComponentTranslation("message.gadget.copysuccess").getUnformattedComponentText()), false);
-                } else {
-                    pasteIsTooLarge();
-                }
-            } catch (IOException e) {
-                BuildingGadgets.logger.error("Failed to evaluate template network size. Template will be considered too large.",e);
-                pasteIsTooLarge();
-            }
+            String jsonTag = newCompound.toString();
+            setClipboardString(jsonTag);
+            Minecraft.getMinecraft().player.sendStatusMessage(new TextComponentString(TextFormatting.AQUA + new TextComponentTranslation("message.gadget.copysuccess").getUnformattedComponentText()), false);
         }
-    }
-
-    private static void pasteIsTooLarge() {
-        Minecraft.getMinecraft().player.sendStatusMessage(new TextComponentString(TextFormatting.RED + new TextComponentTranslation("message.gadget.pastetoobig").getUnformattedComponentText()), false);
     }
 }

--- a/src/main/java/com/direwolf20/buildinggadgets/common/blocks/templatemanager/TemplateManagerGUI.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/blocks/templatemanager/TemplateManagerGUI.java
@@ -15,7 +15,6 @@ import com.direwolf20.buildinggadgets.common.network.PacketHandler;
 import com.direwolf20.buildinggadgets.common.network.PacketTemplateManagerLoad;
 import com.direwolf20.buildinggadgets.common.network.PacketTemplateManagerPaste;
 import com.direwolf20.buildinggadgets.common.network.PacketTemplateManagerSave;
-import com.direwolf20.buildinggadgets.common.tools.GadgetUtils;
 import com.direwolf20.buildinggadgets.common.tools.PasteToolBufferBuilder;
 import com.direwolf20.buildinggadgets.common.tools.ToolDireBuffer;
 import net.minecraft.client.Minecraft;
@@ -307,9 +306,17 @@ public class TemplateManagerGUI extends GuiContainer {
             //System.out.println(CBString);
             try {
                 NBTTagCompound tagCompound = JsonToNBT.getTagFromJson(CBString);
+                //BlockMapIntState MapIntState = GadgetCopyPaste.getBlockMapIntState(tagCompound);
+                int[] stateArray = tagCompound.getIntArray("stateIntArray");
+                //int[] posArray = tagCompound.getIntArray("posIntArray");
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                CompressedStreamTools.writeCompressed(tagCompound, baos);
+                //ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+                //NBTTagCompound newTag = CompressedStreamTools.readCompressed(bais);
+                //System.out.println("BAOS Size: " + baos.size());
 
                 //Anything larger than below is likely to overflow the max packet size, crashing your client.
-                if (GadgetUtils.isSizeValid(tagCompound,nameField.getText())) {
+                if (stateArray.length <= 12000 && baos.size() < 31000) {
                     PacketHandler.INSTANCE.sendToServer(new PacketTemplateManagerPaste(tagCompound, te.getPos(), nameField.getText()));
                     Minecraft.getMinecraft().player.sendStatusMessage(new TextComponentString(TextFormatting.AQUA + new TextComponentTranslation("message.gadget.pastesuccess").getUnformattedComponentText()), false);
                 } else {

--- a/src/main/java/com/direwolf20/buildinggadgets/common/config/Config.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/config/Config.java
@@ -33,6 +33,7 @@ public class Config {
     @Name("Powered by Forge Energy")
     @Comment("Set to true for Forge Energy Support, set to False for vanilla Item Damage")
     @LangKey(LANG_KEY_ROOT+".poweredByFE")
+    @RequiresMcRestart
     public static boolean poweredByFE = true;
 
     @RequiresMcRestart

--- a/src/main/java/com/direwolf20/buildinggadgets/common/events/AnvilRepairHandler.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/events/AnvilRepairHandler.java
@@ -1,16 +1,18 @@
 package com.direwolf20.buildinggadgets.common.events;
 
+import com.direwolf20.buildinggadgets.common.BuildingGadgets;
 import com.direwolf20.buildinggadgets.common.config.SyncedConfig;
 import com.direwolf20.buildinggadgets.common.items.gadgets.GadgetGeneric;
-import com.sun.corba.se.impl.orbutil.concurrent.Sync;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.AnvilUpdateEvent;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
+@EventBusSubscriber(modid = BuildingGadgets.MODID)
 public class AnvilRepairHandler {
     @SubscribeEvent
-    public void onAnvilUpdate(AnvilUpdateEvent event) {
+    public static void onAnvilUpdate(AnvilUpdateEvent event) {
         if (SyncedConfig.poweredByFE && (event.getLeft().getItem() instanceof GadgetGeneric) && (event.getRight().getItem() == Items.DIAMOND)) {
             event.setCost(3);
             event.setMaterialCost(1);

--- a/src/main/java/com/direwolf20/buildinggadgets/common/events/AnvilRepairHandler.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/events/AnvilRepairHandler.java
@@ -1,6 +1,8 @@
 package com.direwolf20.buildinggadgets.common.events;
 
+import com.direwolf20.buildinggadgets.common.config.SyncedConfig;
 import com.direwolf20.buildinggadgets.common.items.gadgets.GadgetGeneric;
+import com.sun.corba.se.impl.orbutil.concurrent.Sync;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.AnvilUpdateEvent;
@@ -9,7 +11,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class AnvilRepairHandler {
     @SubscribeEvent
     public void onAnvilUpdate(AnvilUpdateEvent event) {
-        if ((event.getLeft().getItem() instanceof GadgetGeneric) && (event.getRight().getItem() == Items.DIAMOND)) {
+        if (SyncedConfig.poweredByFE && (event.getLeft().getItem() instanceof GadgetGeneric) && (event.getRight().getItem() == Items.DIAMOND)) {
             event.setCost(3);
             event.setMaterialCost(1);
             ItemStack newItem = event.getLeft().copy();

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/capability/CapabilityProviderEnergy.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/capability/CapabilityProviderEnergy.java
@@ -1,5 +1,6 @@
 package com.direwolf20.buildinggadgets.common.items.capability;
 
+import com.direwolf20.buildinggadgets.common.config.SyncedConfig;
 import com.direwolf20.buildinggadgets.common.tools.GadgetUtils;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
@@ -22,12 +23,12 @@ public class CapabilityProviderEnergy implements ICapabilityProvider {
 
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing) {
-        return capability == CapabilityEnergy.ENERGY;
+        return capability == CapabilityEnergy.ENERGY && SyncedConfig.poweredByFE ;
     }
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing) {
-        return capability == CapabilityEnergy.ENERGY ? CapabilityEnergy.ENERGY.cast(new ItemEnergyForge(stack, energyCapacity)) : null;
+        return capability == CapabilityEnergy.ENERGY && SyncedConfig.poweredByFE ? CapabilityEnergy.ENERGY.cast(new ItemEnergyForge(stack, energyCapacity)) : null;
     }
 
     @Nonnull

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/capability/ItemEnergyForge.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/capability/ItemEnergyForge.java
@@ -39,9 +39,15 @@ public class ItemEnergyForge extends EnergyStorage {
         return super.getMaxEnergyStored();
     }
 
+    @Override
+    public int getEnergyStored() {
+        updateMaxEnergy();
+        return super.getEnergyStored();
+    }
+
     private void updateMaxEnergy() {
         this.capacity = maxEnergyProvider.getAsInt();
-        this.energy = Math.min(capacity, getEnergyStored());
+        this.energy = Math.min(capacity, this.energy);
     }
 
     private int changeEnergy(int amount, boolean simulate) {

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/capability/ItemEnergyForge.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/capability/ItemEnergyForge.java
@@ -41,6 +41,7 @@ public class ItemEnergyForge extends EnergyStorage {
 
     private void updateMaxEnergy() {
         this.capacity = maxEnergyProvider.getAsInt();
+        this.energy = Math.max(capacity, getEnergyStored());
     }
 
     private int changeEnergy(int amount, boolean simulate) {

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/capability/ItemEnergyForge.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/capability/ItemEnergyForge.java
@@ -41,7 +41,7 @@ public class ItemEnergyForge extends EnergyStorage {
 
     private void updateMaxEnergy() {
         this.capacity = maxEnergyProvider.getAsInt();
-        this.energy = Math.max(capacity, getEnergyStored());
+        this.energy = Math.min(capacity, getEnergyStored());
     }
 
     private int changeEnergy(int amount, boolean simulate) {

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetBuilding.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetBuilding.java
@@ -30,6 +30,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldType;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.BlockSnapshot;
+import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.world.BlockEvent;
@@ -59,9 +60,12 @@ public class GadgetBuilding extends GadgetGeneric {
         setRegistryName("buildingtool");        // The unique name (within your mod) that identifies this item
         setUnlocalizedName(BuildingGadgets.MODID + ".buildingtool");     // Used for localization (en_US.lang)
         setMaxStackSize(1);
-        if (!SyncedConfig.poweredByFE) {
-            setMaxDamage(SyncedConfig.durabilityBuilder);
-        }
+        setMaxDamage(SyncedConfig.durabilityBuilder);
+    }
+
+    @Override
+    public int getMaxDamage(ItemStack stack) {
+        return SyncedConfig.poweredByFE?0:SyncedConfig.durabilityBuilder;
     }
 
     @Override
@@ -108,10 +112,7 @@ public class GadgetBuilding extends GadgetGeneric {
         if (getToolMode(stack) != ToolMode.BuildToMe) {
             list.add(TextFormatting.RED + I18n.format("tooltip.gadget.range") + ": " + getToolRange(stack));
         }
-        if (SyncedConfig.poweredByFE) {
-            IEnergyStorage energy = CapabilityProviderEnergy.getCap(stack);
-            list.add(TextFormatting.WHITE + I18n.format("tooltip.gadget.energy") + ": " + withSuffix(energy.getEnergyStored()) + "/" + withSuffix(energy.getMaxEnergyStored()));
-        }
+        addEnergyInformation(list, stack);
     }
 
     @Override

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetCopyPaste.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetCopyPaste.java
@@ -39,7 +39,9 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.BlockSnapshot;
+import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.world.BlockEvent;
@@ -66,9 +68,12 @@ public class GadgetCopyPaste extends GadgetGeneric implements ITemplate {
         setRegistryName("copypastetool");        // The unique name (within your mod) that identifies this item
         setUnlocalizedName(BuildingGadgets.MODID + ".copypastetool");     // Used for localization (en_US.lang)
         setMaxStackSize(1);
-        if (!SyncedConfig.poweredByFE) {
-            setMaxDamage(SyncedConfig.durabilityCopyPaste);
-        }
+        setMaxDamage(SyncedConfig.durabilityCopyPaste);
+    }
+
+    @Override
+    public int getMaxDamage(ItemStack stack) {
+        return SyncedConfig.poweredByFE?0:SyncedConfig.durabilityCopyPaste;
     }
 
     @Override
@@ -236,10 +241,7 @@ public class GadgetCopyPaste extends GadgetGeneric implements ITemplate {
     public void addInformation(ItemStack stack, @Nullable World world, List<String> list, ITooltipFlag b) {
         super.addInformation(stack, world, list, b);
         list.add(TextFormatting.AQUA + I18n.format("tooltip.gadget.mode") + ": " + getToolMode(stack));
-        if (SyncedConfig.poweredByFE) {
-            IEnergyStorage energy = CapabilityProviderEnergy.getCap(stack);
-            list.add(TextFormatting.WHITE + I18n.format("tooltip.gadget.energy") + ": " + withSuffix(energy.getEnergyStored()) + "/" + withSuffix(energy.getMaxEnergyStored()));
-        }
+        addEnergyInformation(list, stack);
         EventTooltip.addTemplatePadding(stack, list);
     }
 

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetDestruction.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetDestruction.java
@@ -49,9 +49,12 @@ public class GadgetDestruction extends GadgetGeneric {
         setRegistryName("destructiontool");        // The unique name (within your mod) that identifies this item
         setUnlocalizedName(BuildingGadgets.MODID + ".destructiontool");     // Used for localization (en_US.lang)
         setMaxStackSize(1);
-        if (!SyncedConfig.poweredByFE) {
-            setMaxDamage(SyncedConfig.durabilityDestruction);
-        }
+        setMaxDamage(SyncedConfig.durabilityDestruction);
+    }
+
+    @Override
+    public int getMaxDamage(ItemStack stack) {
+        return SyncedConfig.poweredByFE?0:SyncedConfig.durabilityDestruction;
     }
 
     @Override
@@ -74,11 +77,7 @@ public class GadgetDestruction extends GadgetGeneric {
         super.addInformation(stack, world, list, b);
         list.add(TextFormatting.RED + I18n.format("tooltip.gadget.destroywarning"));
         list.add(TextFormatting.AQUA + I18n.format("tooltip.gadget.destroyshowoverlay") + ": " + getOverlay(stack));
-        if (SyncedConfig.poweredByFE) {
-            IEnergyStorage energy = stack.getCapability(CapabilityEnergy.ENERGY, null);
-            if (energy != null)
-                list.add(TextFormatting.WHITE + I18n.format("tooltip.gadget.energy") + ": " + withSuffix(energy.getEnergyStored()) + "/" + withSuffix(energy.getMaxEnergyStored()));
-        }
+        addEnergyInformation(list,stack);
     }
 
     @Nullable

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetExchanger.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetExchanger.java
@@ -59,9 +59,12 @@ public class GadgetExchanger extends GadgetGeneric {
         setRegistryName("exchangertool");        // The unique name (within your mod) that identifies this item
         setUnlocalizedName(BuildingGadgets.MODID + ".exchangertool");     // Used for localization (en_US.lang)
         setMaxStackSize(1);
-        if (!SyncedConfig.poweredByFE) {
-            setMaxDamage(SyncedConfig.durabilityExchanger);
-        }
+        setMaxDamage(SyncedConfig.durabilityExchanger);
+    }
+
+    @Override
+    public int getMaxDamage(ItemStack stack) {
+        return SyncedConfig.poweredByFE?0:SyncedConfig.durabilityExchanger;
     }
 
     @Override
@@ -136,10 +139,7 @@ public class GadgetExchanger extends GadgetGeneric {
         list.add(TextFormatting.DARK_GREEN + I18n.format("tooltip.gadget.block") + ": " + getToolBlock(stack).getBlock().getLocalizedName());
         list.add(TextFormatting.AQUA + I18n.format("tooltip.gadget.mode") + ": " + getToolMode(stack));
         list.add(TextFormatting.RED + I18n.format("tooltip.gadget.range") + ": " + getToolRange(stack));
-        if (SyncedConfig.poweredByFE) {
-            IEnergyStorage energy = CapabilityProviderEnergy.getCap(stack);
-            list.add(TextFormatting.WHITE + I18n.format("tooltip.gadget.energy") + ": " + withSuffix(energy.getEnergyStored()) + "/" + withSuffix(energy.getMaxEnergyStored()));
-        }
+        addEnergyInformation(list, stack);
     }
 
     @Override

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetGeneric.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetGeneric.java
@@ -4,19 +4,25 @@ import com.direwolf20.buildinggadgets.common.BuildingGadgets;
 import com.direwolf20.buildinggadgets.common.config.SyncedConfig;
 import com.direwolf20.buildinggadgets.common.items.capability.CapabilityProviderEnergy;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nullable;
+import java.util.List;
+
+import static com.direwolf20.buildinggadgets.common.tools.GadgetUtils.withSuffix;
 
 public class GadgetGeneric extends Item {
 
@@ -36,10 +42,7 @@ public class GadgetGeneric extends Item {
     @Override
     @Nullable
     public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound tag) {
-        if (SyncedConfig.poweredByFE) {
-            return new CapabilityProviderEnergy(stack, this.getEnergyMax());
-        }
-        return null;
+        return new CapabilityProviderEnergy(stack, this.getEnergyMax());
     }
 
     @Override
@@ -54,7 +57,7 @@ public class GadgetGeneric extends Item {
 
     @Override
     public double getDurabilityForDisplay(ItemStack stack) {
-        if (SyncedConfig.poweredByFE) {
+        if (stack.hasCapability(CapabilityEnergy.ENERGY,null)) {
             IEnergyStorage energy = CapabilityProviderEnergy.getCap(stack);
             return 1D - ((double) energy.getEnergyStored() / (double) energy.getMaxEnergyStored());
         }
@@ -64,7 +67,7 @@ public class GadgetGeneric extends Item {
 
     @Override
     public int getRGBDurabilityForDisplay(ItemStack stack) {
-        if (SyncedConfig.poweredByFE) {
+        if (stack.hasCapability(CapabilityEnergy.ENERGY,null)) {
             IEnergyStorage energy = CapabilityProviderEnergy.getCap(stack);
             return MathHelper.hsvToRGB(Math.max(0.0F, (float) energy.getEnergyStored() / (float) energy.getMaxEnergyStored()) / 3.0F, 1.0F, 1.0F);
         }
@@ -74,7 +77,7 @@ public class GadgetGeneric extends Item {
 
     @Override
     public boolean isDamaged(ItemStack stack) {
-        if (SyncedConfig.poweredByFE) {
+        if (stack.hasCapability(CapabilityEnergy.ENERGY,null)) {
             IEnergyStorage energy = CapabilityProviderEnergy.getCap(stack);
             return energy.getEnergyStored() != energy.getMaxEnergyStored();
         }
@@ -84,7 +87,7 @@ public class GadgetGeneric extends Item {
 
     @Override
     public boolean showDurabilityBar(ItemStack stack) {
-        if (SyncedConfig.poweredByFE) {
+        if (stack.hasCapability(CapabilityEnergy.ENERGY,null)) {
             IEnergyStorage energy = CapabilityProviderEnergy.getCap(stack);
             return energy.getEnergyStored() != energy.getMaxEnergyStored();
         }
@@ -94,9 +97,8 @@ public class GadgetGeneric extends Item {
 
     @Override
     public boolean getIsRepairable(ItemStack toRepair, ItemStack repair) {
-        if (SyncedConfig.poweredByFE) {
+        if (toRepair.hasCapability(CapabilityEnergy.ENERGY,null))
             return false;
-        }
         if (repair.getItem() == Items.DIAMOND) {
             return true;
         }
@@ -126,7 +128,7 @@ public class GadgetGeneric extends Item {
         if (player.capabilities.isCreativeMode)
             return true;
 
-        if (SyncedConfig.poweredByFE) {
+        if (tool.hasCapability(CapabilityEnergy.ENERGY,null)) {
             IEnergyStorage energy = CapabilityProviderEnergy.getCap(tool);
             return this.getEnergyCost() <= energy.getEnergyStored();
         }
@@ -134,11 +136,18 @@ public class GadgetGeneric extends Item {
     }
 
     public void applyDamage(ItemStack tool, EntityPlayer player) {
-        if( SyncedConfig.poweredByFE ) {
+        if(tool.hasCapability(CapabilityEnergy.ENERGY,null)) {
             IEnergyStorage energy = CapabilityProviderEnergy.getCap(tool);
             energy.extractEnergy(this.getEnergyCost(), false);
         }
         else
             tool.damageItem(this.getDamagePerUse(), player);
+    }
+
+    protected void addEnergyInformation(List<String> list, ItemStack stack) {
+        if (stack.hasCapability(CapabilityEnergy.ENERGY,null)) {
+            IEnergyStorage energy = CapabilityProviderEnergy.getCap(stack);
+            list.add(TextFormatting.WHITE + I18n.format("tooltip.gadget.energy") + ": " + withSuffix(energy.getEnergyStored()) + "/" + withSuffix(energy.getMaxEnergyStored()));
+        }
     }
 }

--- a/src/main/java/com/direwolf20/buildinggadgets/common/tools/GadgetUtils.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/tools/GadgetUtils.java
@@ -11,7 +11,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTUtil;
@@ -30,8 +29,6 @@ import net.minecraftforge.items.IItemHandler;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,14 +40,6 @@ public class GadgetUtils {
 
     private static String getStackErrorText(ItemStack stack) {
         return "the following stack: [" + stack + "]";
-    }
-
-    public static boolean isSizeValid(@Nonnull NBTTagCompound compound, @Nullable String name) throws IOException{
-        NBTTagCompound withText = name!=null && !name.isEmpty()?compound.copy():compound;
-        if (name!=null && !name.isEmpty()) withText.setString("name",name);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        CompressedStreamTools.writeCompressed(withText, baos);
-        return baos.size()<Short.MAX_VALUE-200;
     }
 
     @Nonnull

--- a/src/main/java/com/direwolf20/buildinggadgets/common/tools/ToolRenders.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/tools/ToolRenders.java
@@ -36,6 +36,7 @@ import net.minecraft.world.WorldType;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.energy.CapabilityEnergy;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL14;
 
@@ -95,12 +96,12 @@ public class ToolRenders {
                 int hasBlocks = InventoryManipulation.countItem(itemStack, player, cache);
                 hasBlocks = hasBlocks + InventoryManipulation.countPaste(player);
                 int hasEnergy = 0;
-                if (SyncedConfig.poweredByFE) {
+                if (stack.hasCapability(CapabilityEnergy.ENERGY,null)) {
                     hasEnergy = CapabilityProviderEnergy.getCap(stack).getEnergyStored();
                 } else {
                     hasEnergy = stack.getMaxDamage() - stack.getItemDamage();
                 }
-                if (player.capabilities.isCreativeMode || (!SyncedConfig.poweredByFE && !stack.isItemStackDamageable())) {
+                if (player.capabilities.isCreativeMode || (!stack.hasCapability(CapabilityEnergy.ENERGY,null) && !stack.isItemStackDamageable())) {
                     hasEnergy = 1000000;
                 }
                 //Prepare the block rendering
@@ -160,7 +161,7 @@ public class ToolRenders {
                     GlStateManager.scale(1.01f, 1.01f, 1.01f);
                     GL14.glBlendColor(1F, 1F, 1F, 0.35f); //Set the alpha of the blocks we are rendering
                     hasBlocks--;
-                    if (SyncedConfig.poweredByFE) {
+                    if (stack.hasCapability(CapabilityEnergy.ENERGY,null)) {
                         hasEnergy = hasEnergy - ModItems.gadgetBuilding.getEnergyCost();
                     } else {
                         hasEnergy--;
@@ -224,12 +225,12 @@ public class ToolRenders {
                 int hasBlocks = InventoryManipulation.countItem(itemStack, player, cache);
                 hasBlocks = hasBlocks + InventoryManipulation.countPaste(player);
                 int hasEnergy = 0;
-                if (SyncedConfig.poweredByFE) {
+                if (stack.hasCapability(CapabilityEnergy.ENERGY,null)) {
                     hasEnergy = CapabilityProviderEnergy.getCap(stack).getEnergyStored();
                 } else {
                     hasEnergy = stack.getMaxDamage() - stack.getItemDamage();
                 }
-                if (player.capabilities.isCreativeMode || (!SyncedConfig.poweredByFE && !stack.isItemStackDamageable())) {
+                if (player.capabilities.isCreativeMode || (!stack.hasCapability(CapabilityEnergy.ENERGY,null) && !stack.isItemStackDamageable())) {
                     hasEnergy = 1000000;
                 }
                 //Prepare the block rendering
@@ -296,7 +297,7 @@ public class ToolRenders {
                     GlStateManager.scale(1.02f, 1.02f, 1.02f);//Slightly Larger block to avoid z-fighting.
                     GL14.glBlendColor(1F, 1F, 1F, 0.55f); //Set the alpha of the blocks we are rendering
                     hasBlocks--;
-                    if (SyncedConfig.poweredByFE) {
+                    if (stack.hasCapability(CapabilityEnergy.ENERGY,null)) {
                         hasEnergy = hasEnergy - ModItems.gadgetExchanger.getEnergyCost();
                     } else {
                         hasEnergy = hasEnergy - 2;


### PR DESCRIPTION
This Fixes a potential, thogh unlikely bug, when a player changes the "poweredByFE" Config option whilst being in a world. Previously it was possible to enter the world with poweredByFE set to false and then set it to true whilst the Game is running. But because the EnergyCapability would only be created, with poweredByFE to true during ItemStack creation, this would result in certain Safety checks performed failing, as the now expected to exist Capability is not present. This is fixed, by always attaching the CapabilityProvider, but only making it return am EnergyItem if the "powered..." is set to true. In the process all checks for poweredByFE have now been replaced, with .hasCapability checks. As a safety measure it is now also forbidden (impossible) to change this config option whilst being in a world (a player should never modify it in-Game...).

Additionally this also fixes a small bug, where changing the MaxEnergy settings whilst being in a world, would not be reflected in already existing Gadgets. This is done, by now handing the maxEnergy through to an IntSupplier, which retrieves the appropiate setting.

The following Tests were performed:

- Verified, that the crash no longer occurs 
- Verified, that the AnvilHandler, which was as requested by @Phylogeny made static still works
- Verified, that updating the MaxEnergy produces the expected results, aka increasing doesn't suddenly create Energy, decreasing caps it out