### PR TITLE
Add ability to bind a Refined Storage network to a gadget as a remote inventory.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,10 +41,15 @@ repositories {
         name 'tterrag\'s Maven' // CTM
         url 'http://maven.tterrag.com/'
     }
+	maven {
+        name 'Raoulvdberge Repo' // RS
+        url 'https://repo.raoulvdberge.com/'
+    }
 }
 
 dependencies {
     deobfCompile "team.chisel.ctm:CTM:MC${minecraft_version}-${ctm_version}:api"
+	deobfCompile "refinedstorage:refinedstorage:${rs_version}:api"
     runtime "team.chisel.ctm:CTM:MC${minecraft_version}-${ctm_version}"
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 dependencies {
     deobfCompile "team.chisel.ctm:CTM:MC${minecraft_version}-${ctm_version}:api"
-	deobfCompile "refinedstorage:refinedstorage:${rs_version}:api"
+    deobfCompile "refinedstorage:refinedstorage:${rs_version}:api"
     runtime "team.chisel.ctm:CTM:MC${minecraft_version}-${ctm_version}"
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,5 @@ version=2.6.0
 minecraft_version=1.12.2
 forge_version=14.23.5.2768
 ctm_version=0.3.2.18
+rs_version=1.6.12-360
 update_json=https://github.com/Direwolf20-MC/BuildingGadgets/raw/master/update.json

--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetCopyPaste.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/GadgetCopyPaste.java
@@ -15,8 +15,6 @@ import com.direwolf20.buildinggadgets.common.network.PacketHandler;
 import com.direwolf20.buildinggadgets.common.tools.*;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
@@ -43,8 +41,6 @@ import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.world.BlockEvent;
-import net.minecraftforge.items.CapabilityItemHandler;
-import net.minecraftforge.items.IItemHandler;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -290,8 +286,7 @@ public class GadgetCopyPaste extends GadgetGeneric implements ITemplate {
             }
         } else {
             if (pos != null && player.isSneaking()) {
-                TileEntity te = world.getTileEntity(pos);
-                if (te != null && te.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null))
+                if (GadgetUtils.getInventory(world, pos) != null)
                     return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, stack);
             }
             if (getToolMode(stack) == ToolMode.Copy) {

--- a/src/main/java/com/direwolf20/buildinggadgets/common/tools/NetworkExtractor.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/tools/NetworkExtractor.java
@@ -1,12 +1,12 @@
 package com.direwolf20.buildinggadgets.common.tools;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.google.common.collect.ImmutableList;
 import com.raoulvdberge.refinedstorage.api.network.INetwork;
 import com.raoulvdberge.refinedstorage.api.util.Action;
 
@@ -17,7 +17,7 @@ public abstract class NetworkExtractor implements IItemHandler {
     private final List<ItemStack> stacks;
 
     protected NetworkExtractor(Collection<ItemStack> stacks) {
-        this.stacks = new ArrayList<>(stacks);
+        this.stacks = stacks.stream().collect(ImmutableList.toImmutableList());
     }
 
     @Override
@@ -28,8 +28,7 @@ public abstract class NetworkExtractor implements IItemHandler {
     @Override
     @Nonnull
     public ItemStack getStackInSlot(int slot) {
-        ItemStack stack = stacks.get(slot);
-        return stack == null ? ItemStack.EMPTY : stack;
+        return stacks.get(slot);
     }
 
     @Override

--- a/src/main/java/com/direwolf20/buildinggadgets/common/tools/NetworkExtractor.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/tools/NetworkExtractor.java
@@ -17,7 +17,7 @@ public abstract class NetworkExtractor implements IItemHandler {
     private final List<ItemStack> stacks;
 
     protected NetworkExtractor(Collection<ItemStack> stacks) {
-        this.stacks = stacks.stream().collect(ImmutableList.toImmutableList());
+        this.stacks = ImmutableList.copyOf(stacks);
     }
 
     @Override

--- a/src/main/java/com/direwolf20/buildinggadgets/common/tools/NetworkExtractor.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/tools/NetworkExtractor.java
@@ -1,0 +1,70 @@
+package com.direwolf20.buildinggadgets.common.tools;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.raoulvdberge.refinedstorage.api.network.INetwork;
+import com.raoulvdberge.refinedstorage.api.util.Action;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+
+public abstract class NetworkExtractor implements IItemHandler {
+    private final List<ItemStack> stacks;
+
+    protected NetworkExtractor(Collection<ItemStack> stacks) {
+        this.stacks = new ArrayList<>(stacks);
+    }
+
+    @Override
+    public int getSlots() {
+        return stacks.size();
+    }
+
+    @Override
+    @Nonnull
+    public ItemStack getStackInSlot(int slot) {
+        ItemStack stack = stacks.get(slot);
+        return stack == null ? ItemStack.EMPTY : stack;
+    }
+
+    @Override
+    @Nonnull
+    public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+        return ItemStack.EMPTY;
+    }
+
+    @Nullable
+    public abstract ItemStack extractItemInternal(int slot, int amount, boolean simulate);
+
+    @Override
+    @Nonnull
+    public ItemStack extractItem(int slot, int amount, boolean simulate) {
+        ItemStack stack = extractItemInternal(slot, amount, simulate);
+        return stack == null ? ItemStack.EMPTY : stack;
+    }
+
+    @Override
+    public int getSlotLimit(int slot) {
+        return Integer.MAX_VALUE;
+    }
+
+    public static class NetworkExtractorRS extends NetworkExtractor {
+        private INetwork network;
+
+        public NetworkExtractorRS(INetwork network) {
+            super(network.getItemStorageCache().getList().getStacks());
+            this.network = network;
+        }
+
+        @Override
+        @Nullable
+        public ItemStack extractItemInternal(int slot, int amount, boolean simulate) {
+            return network.extractItem(getStackInSlot(slot), amount, simulate ? Action.SIMULATE : Action.PERFORM);
+        }
+    }
+}


### PR DESCRIPTION
Binding any block with a tile entity that is part of an RS network will grant access to the entire network.