### PR TITLE
Make FieldWrappers internally type-safe to allow for proper checks

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/common/config/fieldmap/FieldMapper.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/config/fieldmap/FieldMapper.java
@@ -1,14 +1,8 @@
 package com.direwolf20.buildinggadgets.common.config.fieldmap;
 
 import com.direwolf20.buildinggadgets.common.config.PatternList;
-import com.google.common.collect.ImmutableList;
-import net.minecraft.block.Block;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
-import java.util.Objects;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 /**
  * Class representing a bijective Function and it's reverse Function used to Mapping Field Types to other Types which can be
@@ -19,31 +13,36 @@ import java.util.stream.Stream;
  * @param <SyncedVal> The Type of Synced Value this Mapper maps to
  */
 public class FieldMapper<FieldVal, SyncedVal> {
-    public static final String BLOCK_LIST_MAPPER_ID = "Block List Mapper";
+    //public static final String BLOCK_LIST_MAPPER_ID = "Block List Mapper";
     public static final String PATTERN_LIST_MAPPER_ID = "Pattern List Mapper";
-
-    public static final FieldMapper<Object, Object> GENERIC_IDENTITY_MAPPER = id();
-    public static final FieldMapper<ImmutableList<Block>, String[]> BLOCK_LIST_MAPPER = of(
-            (list) -> list.stream().map((b) -> Objects.requireNonNull(b.getRegistryName()).toString()).toArray(String[]::new),
-            (strings) -> Stream.of(strings).map(ResourceLocation::new).map(ForgeRegistries.BLOCKS::getValue).collect(ImmutableList.toImmutableList()));
+    /*@SuppressWarnings("unchecked")
+    public static final FieldMapper<ImmutableList, String[]> BLOCK_LIST_MAPPER = of(
+            (list) -> ((ImmutableList<Block>)list).stream().map((b) -> Objects.requireNonNull(b.getRegistryName()).toString()).toArray(String[]::new),
+            (strings) -> Stream.of(strings).map(ResourceLocation::new).map(ForgeRegistries.BLOCKS::getValue).collect(ImmutableList.toImmutableList()),
+            ImmutableList.class,String[].class);*/
     public static final FieldMapper<PatternList, String[]> PATTERN_LIST_MAPPER = of(
-            PatternList::toArray,
-            PatternList::ofResourcePattern);
+            PatternList::toArray, PatternList::ofResourcePattern,
+            PatternList.class, String[].class);
 
     private final Function<FieldVal, SyncedVal> fieldToSync;
     private final Function<SyncedVal, FieldVal> syncToField;
+    private final Class<FieldVal> fieldType;
+    private final Class<SyncedVal> syncedType;
 
-    public static <F> FieldMapper<F, F> id() {
-        return of(Function.identity(), Function.identity());
+    public static <F> FieldMapper<F, F> id(Class<F> theClass) {
+        return of(Function.identity(), Function.identity(), theClass, theClass);
     }
 
-    public static <FieldVal, SyncedVal> FieldMapper<FieldVal, SyncedVal> of(Function<FieldVal, SyncedVal> fieldToSync, Function<SyncedVal, FieldVal> syncToField) {
-        return new FieldMapper<FieldVal, SyncedVal>(fieldToSync,syncToField){};
+    public static <FieldVal, SyncedVal> FieldMapper<FieldVal, SyncedVal> of(Function<FieldVal, SyncedVal> fieldToSync, Function<SyncedVal, FieldVal> syncToField, Class<FieldVal> fieldType, Class<SyncedVal> syncedType) {
+        return new FieldMapper<FieldVal, SyncedVal>(fieldToSync, syncToField, fieldType, syncedType) {
+        };
     }
 
-    private FieldMapper(Function<FieldVal, SyncedVal> fieldToSync, Function<SyncedVal, FieldVal> syncToField) {
+    private FieldMapper(Function<FieldVal, SyncedVal> fieldToSync, Function<SyncedVal, FieldVal> syncToField, Class<FieldVal> fieldType, Class<SyncedVal> syncedType) {
         this.fieldToSync = fieldToSync;
         this.syncToField = syncToField;
+        this.fieldType = fieldType;
+        this.syncedType = syncedType;
     }
 
     public SyncedVal mapToSync(FieldVal val) {
@@ -52,5 +51,13 @@ public class FieldMapper<FieldVal, SyncedVal> {
 
     public FieldVal mapToField(SyncedVal val) {
         return syncToField.apply(val);
+    }
+
+    public Class<FieldVal> getFieldType() {
+        return fieldType;
+    }
+
+    public Class<SyncedVal> getSyncedType() {
+        return syncedType;
     }
 }

--- a/src/main/java/com/direwolf20/buildinggadgets/common/config/fieldmap/FieldWrapper.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/config/fieldmap/FieldWrapper.java
@@ -45,20 +45,20 @@ public final class FieldWrapper {
      * @see Field#get(Object)
      */
     public <T> T get(Class<T> clazz) throws IllegalAccessException {
-        if (!clazz.isAssignableFrom(getMappedType())) {
-            throw new IllegalArgumentException("Attempted to retrieve value of type " + clazz.getName() + " but this wrapper only accepts " + mapper.getSyncedType());
-        }
+        Preconditions.checkArgument(clazz.isAssignableFrom(getMappedType()),
+                "Attempted to retrieve value of type " + clazz.getName() + " but this wrapper only accepts " + mapper.getSyncedType().getName());
         if (val == null) val = mapper.mapToSync(field.get(instance));
-        return clazz.cast(val);
+        @SuppressWarnings("unchecked")
+        T obj = (T) val; //Cannot call clazz.cast as this will throw an exception when faced with an primitive type - we already check before, so this should be fine
+        return obj;
     }
     /**
      *
      * @see Field#set(Object, Object)
      */
     public <T> void set(T val, Class<T> clazz) throws IllegalAccessException {
-        if (!clazz.isAssignableFrom(getMappedType())) {
-            throw new IllegalArgumentException("Attempted to set value of type " + clazz.getName() + " but this wrapper only accepts " + mapper.getSyncedType());
-        }
+        Preconditions.checkArgument(clazz.isAssignableFrom(getMappedType()),
+                "Attempted to set value of type " + clazz.getName() + " but this wrapper only accepts " + mapper.getSyncedType().getName());
         field.set(instance, mapper.mapToField(val));
     }
 

--- a/src/main/java/com/direwolf20/buildinggadgets/common/config/fieldmap/FieldWrapper.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/config/fieldmap/FieldWrapper.java
@@ -32,6 +32,8 @@ public final class FieldWrapper {
     public FieldWrapper(@Nonnull Field field, @Nonnull FieldMapper<?, ?> mapper, @Nullable Object instance) {
         Preconditions.checkArgument(ReflectionTool.isInstanceProvidedForField(field, instance),
                 "Non Static fields must be accessed with an instance! Static fields without! Also watch out for incompatible classes! ");
+        Preconditions.checkArgument(field.getType().isAssignableFrom(mapper.getFieldType()),
+                "The Mapper must map to an assignableField Type! Mapper has Type " + mapper.getFieldType().getName() + " but at least " + field.getType().getName() + " is required!");
         this.instance = instance;
         this.field = field;
         this.mapper = (FieldMapper<Object, Object>) mapper;
@@ -42,23 +44,39 @@ public final class FieldWrapper {
      * @implNote Performs caching under the assumption that the underlying Field will not change during the life-time of this Object
      * @see Field#get(Object)
      */
-    public Object get() throws IllegalAccessException{
+    public <T> T get(Class<T> clazz) throws IllegalAccessException {
+        if (!clazz.isAssignableFrom(getMappedType())) {
+            throw new IllegalArgumentException("Attempted to retrieve value of type " + clazz.getName() + " but this wrapper only accepts " + mapper.getSyncedType());
+        }
         if (val == null) val = mapper.mapToSync(field.get(instance));
-        return val;
+        return clazz.cast(val);
     }
     /**
      *
      * @see Field#set(Object, Object)
      */
-    public void set(Object val) throws IllegalAccessException{
+    public <T> void set(T val, Class<T> clazz) throws IllegalAccessException {
+        if (!clazz.isAssignableFrom(getMappedType())) {
+            throw new IllegalArgumentException("Attempted to set value of type " + clazz.getName() + " but this wrapper only accepts " + mapper.getSyncedType());
+        }
         field.set(instance, mapper.mapToField(val));
     }
 
     /**
      *
+     * @return The type a Field must have, to be usable by this wrapper
      * @see Field#getType()
      */
-    public Class<?> getType() {
-        return field.getType();
+    public Class<?> getFieldType() {
+        return mapper.getFieldType();
     }
+
+    /**
+     * @return The type this wrapper accepts values for
+     */
+    public Class<?> getMappedType() {
+        return mapper.getSyncedType();
+    }
+
+
 }


### PR DESCRIPTION
Make Field mapping actually type-safe. This has the advantage that we can now do proper type checks, at the cost of not being able to use any generic Types in the SyncedConfig class. I think we can live with that.