### PR TITLE
GuiMod cleanup

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/common/utils/helpers/InventoryHelper.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/utils/helpers/InventoryHelper.java
@@ -362,4 +362,23 @@ public class InventoryHelper {
         return placeState;
 
     }
+
+    /**
+     * Find an item stack in either hand that delegates to the given {@code itemClass}.
+     * <p>
+     * This method will prioritize primary hand, which means if player hold the desired item on both hands, it will
+     * choose his primary hand first. If neither hands have the desired item stack, it will return {@link
+     * ItemStack#EMPTY}.
+     *
+     * @return {@link ItemStack#EMPTY} when neither hands met the parameter.
+     */
+    public static ItemStack getStackInEitherHand(EntityPlayer player, Class<?> itemClass) {
+        ItemStack mainHand = player.getHeldItemMainhand();
+        if (itemClass.isInstance(mainHand.getItem()))
+            return mainHand;
+        ItemStack offhand = player.getHeldItemOffhand();
+        if (itemClass.isInstance(offhand.getItem()))
+            return offhand;
+        return ItemStack.EMPTY;
+    }
 }

--- a/src/main/java/com/direwolf20/buildinggadgets/common/utils/helpers/InventoryHelper.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/utils/helpers/InventoryHelper.java
@@ -362,23 +362,4 @@ public class InventoryHelper {
         return placeState;
 
     }
-
-    /**
-     * Find an item stack in either hand that delegates to the given {@code itemClass}.
-     * <p>
-     * This method will prioritize primary hand, which means if player hold the desired item on both hands, it will
-     * choose his primary hand first. If neither hands have the desired item stack, it will return {@link
-     * ItemStack#EMPTY}.
-     *
-     * @return {@link ItemStack#EMPTY} when neither hands met the parameter.
-     */
-    public static ItemStack getStackInEitherHand(EntityPlayer player, Class<?> itemClass) {
-        ItemStack mainHand = player.getHeldItemMainhand();
-        if (itemClass.isInstance(mainHand.getItem()))
-            return mainHand;
-        ItemStack offhand = player.getHeldItemOffhand();
-        if (itemClass.isInstance(offhand.getItem()))
-            return offhand;
-        return ItemStack.EMPTY;
-    }
 }


### PR DESCRIPTION
As I'm doing the material list GUI for template items, I came across this problem: `GuiMod` only supports gadgets (`GadgetUtils#getGadget(EntityPlayer)`) and is not very flexible.

## Additions

This PR split the original `GuiMod` into two enums, `CommonGui` and `ClientGui`. This allows greater flexibility and avoids partially used fields. Currently only template manager GUI locates at `CommonGui`, and the rest gaget GUIs locates at the `ClientGui` enum.

---

The above description hasn't been implemented yet, as I want to get a approval to do it. If this doesn't get approved, making `GuiMod` support items other than gadgets will be done in the material list PR.