### PR TITLE
Potentially fix #410

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/AbstractGadget.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/items/gadgets/AbstractGadget.java
@@ -167,7 +167,7 @@ public abstract class AbstractGadget extends Item {
         if (isAllowedBlock(block))
             return true;
         if (notifiedPlayer != null)
-            notifiedPlayer.sendStatusMessage(MessageTranslation.INVALID_BLOCK.componentTranslation(block.getNameTextComponent()).setStyle(Styles.AQUA), true);
+            notifiedPlayer.sendStatusMessage(MessageTranslation.INVALID_BLOCK.componentTranslation(new TranslationTextComponent(block.getTranslationKey())).setStyle(Styles.AQUA), true);
         return false;
     }
 

--- a/src/main/java/com/direwolf20/buildinggadgets/common/util/lang/LangUtil.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/util/lang/LangUtil.java
@@ -19,7 +19,6 @@ public final class LangUtil {
     }
 
     public static String getFormattedBlockName(Block block) {
-        return block.getNameTextComponent().getFormattedText();
+        return new TranslationTextComponent(block.getTranslationKey()).getFormattedText();
     }
-
 }


### PR DESCRIPTION
As Block::getNameTextComponent is annotated as `@OnlyIn(Dist.CLIENT)`, instead of calling that, just do what it does: create a new TranslationTextComponent using the block's translation key.