### PR TITLE
Fixed template rotation

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/common/util/tools/MathUtils.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/util/tools/MathUtils.java
@@ -112,24 +112,24 @@ public final class MathUtils {
             case X: {
                 matrix[0][0] = 1;
                 matrix[1][1] = cosineForRotation(rotation);
-                matrix[1][2] = - sineForRotation(rotation);
-                matrix[2][1] = sineForRotation(rotation);
+                matrix[1][2] = sineForRotation(rotation);
+                matrix[2][1] = - sineForRotation(rotation);
                 matrix[2][2] = cosineForRotation(rotation);
                 break;
             }
             case Y: {
                 matrix[1][1] = 1;
                 matrix[0][0] = cosineForRotation(rotation);
-                matrix[2][0] = - sineForRotation(rotation);
-                matrix[0][2] = sineForRotation(rotation);
+                matrix[2][0] = sineForRotation(rotation);
+                matrix[0][2] = - sineForRotation(rotation);
                 matrix[2][2] = cosineForRotation(rotation);
                 break;
             }
             case Z: {
                 matrix[2][2] = 1;
                 matrix[0][0] = cosineForRotation(rotation);
-                matrix[0][1] = - sineForRotation(rotation);
-                matrix[1][0] = sineForRotation(rotation);
+                matrix[0][1] = sineForRotation(rotation);
+                matrix[1][0] = - sineForRotation(rotation);
                 matrix[1][1] = cosineForRotation(rotation);
                 break;
             }


### PR DESCRIPTION
Fixed rotating a template to use the wrong calculation for the rotation matrix causing the blocks to be placed incorrectly.

Fixes #478