### PR TITLE
Added an Interface to allow for more nuanced IItemHandlers

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/common/integration/IBlockProviderItemHandler.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/integration/IBlockProviderItemHandler.java
@@ -1,0 +1,26 @@
+package com.direwolf20.buildinggadgets.common.integration;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+
+public interface IBlockProviderItemHandler extends IItemHandler {
+
+	/**
+	 * Returns the amount of a certain ItemStack that this IItemHandler currently has
+	 * @param toCount The ItemStack to count
+	 * @param player The player
+	 * @return The count of this item in the IItemHandler
+	 */
+	public int getItemCount(ItemStack toCount, EntityPlayer player);
+
+	/**
+	 * Extracts the requested amount (or less) of the specified item from the IItemHandler.
+	 * @param toExtract The ItemStack to extract
+	 * @param maxCount The maximum count that should be extracted
+	 * @param player The player
+	 * @return The amount that was actually extracted
+	 */
+	public int extractItems(ItemStack toExtract, int maxCount, EntityPlayer player);
+	
+}

--- a/src/main/java/com/direwolf20/buildinggadgets/common/integration/IItemAccess.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/integration/IItemAccess.java
@@ -4,10 +4,10 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 
-public interface IBlockProviderItemHandler extends IItemHandler {
+public interface IItemAccess extends IItemHandler {
 
 	/**
-	 * Returns the amount of a certain ItemStack that this IItemHandler currently has
+	 * Returns the amount of a certain {@link ItemStack} that this {@link IItemHandler} currently has (and can extract) without modifying it.
 	 * @param toCount The ItemStack to count
 	 * @param player The player
 	 * @return The count of this item in the IItemHandler
@@ -15,8 +15,8 @@ public interface IBlockProviderItemHandler extends IItemHandler {
 	public int getItemCount(ItemStack toCount, EntityPlayer player);
 
 	/**
-	 * Extracts the requested amount (or less) of the specified item from the IItemHandler.
-	 * @param toExtract The ItemStack to extract
+	 * Extracts the requested amount (or less) of the specified item from the {@link IItemHandler}.
+	 * @param toExtract The {@link ItemStack} to extract
 	 * @param maxCount The maximum count that should be extracted
 	 * @param player The player
 	 * @return The amount that was actually extracted

--- a/src/main/java/com/direwolf20/buildinggadgets/common/integration/IItemAccess.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/integration/IItemAccess.java
@@ -12,7 +12,7 @@ public interface IItemAccess extends IItemHandler {
 	 * @param player The player
 	 * @return The count of this item in the IItemHandler
 	 */
-	public int getItemCount(ItemStack toCount, EntityPlayer player);
+	public int getItemsForExtraction(ItemStack toCount, EntityPlayer player);
 
 	/**
 	 * Extracts the requested amount (or less) of the specified item from the {@link IItemHandler}.

--- a/src/main/java/com/direwolf20/buildinggadgets/common/tools/InventoryManipulation.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/tools/InventoryManipulation.java
@@ -1,6 +1,6 @@
 package com.direwolf20.buildinggadgets.common.tools;
 
-import com.direwolf20.buildinggadgets.common.integration.IBlockProviderItemHandler;
+import com.direwolf20.buildinggadgets.common.integration.IItemAccess;
 import com.direwolf20.buildinggadgets.common.items.ModItems;
 import com.direwolf20.buildinggadgets.common.items.gadgets.GadgetCopyPaste;
 import com.direwolf20.buildinggadgets.common.items.gadgets.GadgetGeneric;
@@ -137,8 +137,8 @@ public class InventoryManipulation {
         if( inventory == null )
             return amountSaturated;
 
-        if(inventory instanceof IBlockProviderItemHandler) {
-        	amountSaturated += ((IBlockProviderItemHandler) inventory).extractItems(target, amountRequired - amountSaturated, player);
+        if(inventory instanceof IItemAccess) {
+        	amountSaturated += ((IItemAccess) inventory).extractItems(target, amountRequired - amountSaturated, player);
         	return amountSaturated;
         }
         
@@ -206,8 +206,8 @@ public class InventoryManipulation {
     public static int countItem(ItemStack itemStack, EntityPlayer player, World world) {
         return countItem(itemStack, player, (tool, stack) -> {
             IItemHandler remoteInventory = GadgetUtils.getRemoteInventory(tool, world, player);
-            if(remoteInventory instanceof IBlockProviderItemHandler)
-    			return ((IBlockProviderItemHandler) remoteInventory).getItemCount(stack, player);
+            if(remoteInventory instanceof IItemAccess)
+    			return ((IItemAccess) remoteInventory).getItemCount(stack, player);
             return remoteInventory == null ? 0 : countInContainer(remoteInventory, stack.getItem(), stack.getMetadata());
         });
     }
@@ -231,8 +231,8 @@ public class InventoryManipulation {
         if (invContainers.size() > 0) {
             for (IItemHandler container : invContainers) {
             	{
-            		if(container instanceof IBlockProviderItemHandler)
-            			count += ((IBlockProviderItemHandler) container).getItemCount(itemStack, player);
+            		if(container instanceof IItemAccess)
+            			count += ((IItemAccess) container).getItemCount(itemStack, player);
             		else
             			count += countInContainer(container, itemStack.getItem(), itemStack.getMetadata());
             	}

--- a/src/main/java/com/direwolf20/buildinggadgets/common/tools/InventoryManipulation.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/tools/InventoryManipulation.java
@@ -1,11 +1,13 @@
 package com.direwolf20.buildinggadgets.common.tools;
 
+import com.direwolf20.buildinggadgets.common.integration.IBlockProviderItemHandler;
 import com.direwolf20.buildinggadgets.common.items.ModItems;
 import com.direwolf20.buildinggadgets.common.items.gadgets.GadgetCopyPaste;
 import com.direwolf20.buildinggadgets.common.items.gadgets.GadgetGeneric;
 import com.direwolf20.buildinggadgets.common.items.pastes.ConstructionPaste;
 import com.direwolf20.buildinggadgets.common.items.pastes.GenericPasteContainer;
 import com.google.common.collect.ImmutableSet;
+
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.minecraft.block.*;
@@ -121,7 +123,7 @@ public class InventoryManipulation {
 
         int amountLeft = amountRequired;
         for (Pair<InventoryType, IItemHandler> inv : collectInventories(GadgetGeneric.getGadget(player), player, world, NetworkIO.Operation.EXTRACT)) {
-            amountLeft -= extractFromInventory(inv.getValue(), target, amountLeft);
+            amountLeft -= extractFromInventory(inv.getValue(), target, amountLeft, player);
 
             if( amountLeft <= 0 )
                 return true;
@@ -130,11 +132,16 @@ public class InventoryManipulation {
         return amountLeft < amountRequired;
     }
 
-    private static int extractFromInventory(IItemHandler inventory, ItemStack target, int amountRequired) {
+    private static int extractFromInventory(IItemHandler inventory, ItemStack target, int amountRequired, EntityPlayer player) {
         int amountSaturated = 0;
         if( inventory == null )
             return amountSaturated;
 
+        if(inventory instanceof IBlockProviderItemHandler) {
+        	amountSaturated += ((IBlockProviderItemHandler) inventory).extractItems(target, amountRequired - amountSaturated, player);
+        	return amountSaturated;
+        }
+        
         for (int i = 0; i < inventory.getSlots(); i++) {
             ItemStack containerItem = inventory.getStackInSlot(i);
             if (containerItem.getItem() == target.getItem() && containerItem.getMetadata() == target.getMetadata()) {
@@ -199,6 +206,8 @@ public class InventoryManipulation {
     public static int countItem(ItemStack itemStack, EntityPlayer player, World world) {
         return countItem(itemStack, player, (tool, stack) -> {
             IItemHandler remoteInventory = GadgetUtils.getRemoteInventory(tool, world, player);
+            if(remoteInventory instanceof IBlockProviderItemHandler)
+    			return ((IBlockProviderItemHandler) remoteInventory).getItemCount(stack, player);
             return remoteInventory == null ? 0 : countInContainer(remoteInventory, stack.getItem(), stack.getMetadata());
         });
     }
@@ -221,7 +230,12 @@ public class InventoryManipulation {
 
         if (invContainers.size() > 0) {
             for (IItemHandler container : invContainers) {
-                count += countInContainer(container, itemStack.getItem(), itemStack.getMetadata());
+            	{
+            		if(container instanceof IBlockProviderItemHandler)
+            			count += ((IBlockProviderItemHandler) container).getItemCount(itemStack, player);
+            		else
+            			count += countInContainer(container, itemStack.getItem(), itemStack.getMetadata());
+            	}
             }
         }
 

--- a/src/main/java/com/direwolf20/buildinggadgets/common/tools/InventoryManipulation.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/tools/InventoryManipulation.java
@@ -207,7 +207,7 @@ public class InventoryManipulation {
         return countItem(itemStack, player, (tool, stack) -> {
             IItemHandler remoteInventory = GadgetUtils.getRemoteInventory(tool, world, player);
             if(remoteInventory instanceof IItemAccess)
-    			return ((IItemAccess) remoteInventory).getItemCount(stack, player);
+    			return ((IItemAccess) remoteInventory).getItemsForExtraction(stack, player);
             return remoteInventory == null ? 0 : countInContainer(remoteInventory, stack.getItem(), stack.getMetadata());
         });
     }
@@ -232,7 +232,7 @@ public class InventoryManipulation {
             for (IItemHandler container : invContainers) {
             	{
             		if(container instanceof IItemAccess)
-            			count += ((IItemAccess) container).getItemCount(itemStack, player);
+            			count += ((IItemAccess) container).getItemsForExtraction(itemStack, player);
             		else
             			count += countInContainer(container, itemStack.getItem(), itemStack.getMetadata());
             	}


### PR DESCRIPTION
Adds #477 
Just a small interface which IItemHandlers of other mods should implement. 

It allows IItemHandlers to bypass the normal block counting methods and implement their own. This is useful for mods that have some special behavior which does not allow them to expose the exact contents of the IItemHandler, like for example an infinite supply of cobblestone. 

It was tested together with a (not yet public) version of Builder's Bag and was found to be working as expected.