### PR TITLE
Improve the BoundingBox class

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/common/construction/modes/SurfaceMode.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/construction/modes/SurfaceMode.java
@@ -2,12 +2,12 @@ package com.direwolf20.buildinggadgets.common.construction.modes;
 
 import com.direwolf20.buildinggadgets.common.construction.ModeUseContext;
 import com.direwolf20.buildinggadgets.common.schema.BoundingBox;
-import com.google.common.collect.ImmutableList;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class SurfaceMode extends Mode {
     public SurfaceMode(boolean isExchanging) { super("surface", isExchanging); }
@@ -22,7 +22,7 @@ public class SurfaceMode extends Mode {
                 bound * (1 - Math.abs(context.getHitSide().getZOffset()))
         );
 
-        return ImmutableList.copyOf(region);
+        return region.stream().collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/direwolf20/buildinggadgets/common/construction/modes/SurfaceMode.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/construction/modes/SurfaceMode.java
@@ -2,12 +2,12 @@ package com.direwolf20.buildinggadgets.common.construction.modes;
 
 import com.direwolf20.buildinggadgets.common.construction.ModeUseContext;
 import com.direwolf20.buildinggadgets.common.schema.BoundingBox;
+import com.google.common.collect.ImmutableList;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class SurfaceMode extends Mode {
     public SurfaceMode(boolean isExchanging) { super("surface", isExchanging); }
@@ -22,7 +22,7 @@ public class SurfaceMode extends Mode {
                 bound * (1 - Math.abs(context.getHitSide().getZOffset()))
         );
 
-        return region.stream().collect(Collectors.toList());
+        return ImmutableList.copyOf(region);
     }
 
     @Override

--- a/src/main/java/com/direwolf20/buildinggadgets/common/construction/modes/SurfaceMode.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/construction/modes/SurfaceMode.java
@@ -4,17 +4,16 @@ import com.direwolf20.buildinggadgets.common.construction.ModeUseContext;
 import com.direwolf20.buildinggadgets.common.schema.BoundingBox;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.util.math.*;
+import net.minecraft.util.math.BlockPos;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class SurfaceMode extends Mode {
     public SurfaceMode(boolean isExchanging) { super("surface", isExchanging); }
 
     @Override
     List<BlockPos> collect(ModeUseContext context, PlayerEntity player, BlockPos start) {
-        List<BlockPos> coordinates = new ArrayList<>();
 
         int bound = context.getRange() / 2;
         BoundingBox region = new BoundingBox(start).expand(
@@ -23,12 +22,7 @@ public class SurfaceMode extends Mode {
                 bound * (1 - Math.abs(context.getHitSide().getZOffset()))
         );
 
-        CubeCoordinateIterator iterator = new CubeCoordinateIterator(region.minX, region.minY, region.minZ, region.maxX, region.maxY, region.maxZ);
-        while( iterator.hasNext() ) {
-            coordinates.add(new BlockPos(iterator.getX(), iterator.getY(), iterator.getZ()));
-        }
-
-        return coordinates;
+        return region.stream().collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/direwolf20/buildinggadgets/common/schema/BoundingBox.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/schema/BoundingBox.java
@@ -35,30 +35,6 @@ public final class BoundingBox implements Iterable<BlockPos> {
         this(min.getX(), min.getY(), min.getZ(), max.getX(), max.getY(), max.getZ());
     }
 
-    public int getMinX() {
-        return minX;
-    }
-
-    public int getMinY() {
-        return minY;
-    }
-
-    public int getMinZ() {
-        return minZ;
-    }
-
-    public int getMaxX() {
-        return maxX;
-    }
-
-    public int getMaxY() {
-        return maxY;
-    }
-
-    public int getMaxZ() {
-        return maxZ;
-    }
-
     public BoundingBox expand(int x, int y, int z) {
         return new BoundingBox(minX - x, minY - y, minZ - z, maxX + x, maxY + y, maxZ + z);
     }
@@ -89,6 +65,30 @@ public final class BoundingBox implements Iterable<BlockPos> {
 
     public Stream<BlockPos> stream() {
         return StreamSupport.stream(spliterator(), false);
+    }
+
+    public int getMinX() {
+        return minX;
+    }
+
+    public int getMinY() {
+        return minY;
+    }
+
+    public int getMinZ() {
+        return minZ;
+    }
+
+    public int getMaxX() {
+        return maxX;
+    }
+
+    public int getMaxY() {
+        return maxY;
+    }
+
+    public int getMaxZ() {
+        return maxZ;
     }
 
     @Override

--- a/src/main/java/com/direwolf20/buildinggadgets/common/schema/BoundingBox.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/schema/BoundingBox.java
@@ -43,7 +43,7 @@ public final class BoundingBox {
     }
 
     public Stream<BlockPos> stream() {
-        return BlockPos.getAllInBox(minX, minY, minZ, maxX, maxY, maxZ);
+        return BlockPos.getAllInBox(minX, minY, minZ, maxX, maxY, maxZ).map(BlockPos::toImmutable);
     }
 
     public int getMinX() {

--- a/src/main/java/com/direwolf20/buildinggadgets/common/schema/BoundingBox.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/schema/BoundingBox.java
@@ -1,19 +1,22 @@
 package com.direwolf20.buildinggadgets.common.schema;
 
+import com.google.common.collect.AbstractIterator;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MutableBoundingBox;
+import net.minecraft.util.math.CubeCoordinateIterator;
 import net.minecraft.util.math.Vec3i;
 
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
-public class BoundingBox {
-    public int minX;
-    public int minY;
-    public int minZ;
-    public int maxX;
-    public int maxY;
-    public int maxZ;
+public final class BoundingBox implements Iterable<BlockPos> {
+    private final int minX;
+    private final int minY;
+    private final int minZ;
+    private final int maxX;
+    private final int maxY;
+    private final int maxZ;
 
     public BoundingBox(int minX, int minY, int minZ, int maxX, int maxY, int maxZ) {
         this.minX = Math.min(minX, maxX);
@@ -32,6 +35,30 @@ public class BoundingBox {
         this(min.getX(), min.getY(), min.getZ(), max.getX(), max.getY(), max.getZ());
     }
 
+    public int getMinX() {
+        return minX;
+    }
+
+    public int getMinY() {
+        return minY;
+    }
+
+    public int getMinZ() {
+        return minZ;
+    }
+
+    public int getMaxX() {
+        return maxX;
+    }
+
+    public int getMaxY() {
+        return maxY;
+    }
+
+    public int getMaxZ() {
+        return maxZ;
+    }
+
     public BoundingBox expand(int x, int y, int z) {
         return new BoundingBox(minX - x, minY - y, minZ - z, maxX + x, maxY + y, maxZ + z);
     }
@@ -42,7 +69,28 @@ public class BoundingBox {
     public BoundingBox grow(int x, int y, int z) {
         return new BoundingBox(minX, minY, minZ, maxX + x, maxY + y, maxZ + z);
     }
-    
+
+    public CubeCoordinateIterator cubeIterator() {
+        return new CubeCoordinateIterator(minX, minY, minZ, maxX, maxY, maxZ);
+    }
+
+    @Override
+    public Iterator<BlockPos> iterator() {
+        return new AbstractIterator<BlockPos>() {
+            private final CubeCoordinateIterator it = cubeIterator();
+            @Override
+            protected BlockPos computeNext() {
+                if (!it.hasNext())
+                    return endOfData();
+                return new BlockPos(it.getX(), it.getY(), it.getZ());
+            }
+        };
+    }
+
+    public Stream<BlockPos> stream() {
+        return StreamSupport.stream(spliterator(), false);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/direwolf20/buildinggadgets/common/schema/BoundingBox.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/schema/BoundingBox.java
@@ -1,16 +1,12 @@
 package com.direwolf20.buildinggadgets.common.schema;
 
-import com.google.common.collect.AbstractIterator;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.CubeCoordinateIterator;
 import net.minecraft.util.math.Vec3i;
 
-import java.util.Iterator;
 import java.util.Objects;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
-public final class BoundingBox implements Iterable<BlockPos> {
+public final class BoundingBox {
     private final int minX;
     private final int minY;
     private final int minZ;
@@ -46,25 +42,8 @@ public final class BoundingBox implements Iterable<BlockPos> {
         return new BoundingBox(minX, minY, minZ, maxX + x, maxY + y, maxZ + z);
     }
 
-    public CubeCoordinateIterator cubeIterator() {
-        return new CubeCoordinateIterator(minX, minY, minZ, maxX, maxY, maxZ);
-    }
-
-    @Override
-    public Iterator<BlockPos> iterator() {
-        return new AbstractIterator<BlockPos>() {
-            private final CubeCoordinateIterator it = cubeIterator();
-            @Override
-            protected BlockPos computeNext() {
-                if (!it.hasNext())
-                    return endOfData();
-                return new BlockPos(it.getX(), it.getY(), it.getZ());
-            }
-        };
-    }
-
     public Stream<BlockPos> stream() {
-        return StreamSupport.stream(spliterator(), false);
+        return BlockPos.getAllInBox(minX, minY, minZ, maxX, maxY, maxZ);
     }
 
     public int getMinX() {


### PR DESCRIPTION
These are changes I'd do for the Template implementation anyway:

- The `BoundingBox` no longer has public (and even mutable!!!) fields~~
- ~~It exposes the `CubeCoordinateIterator` directly and even enables iteration of the represented `BlockPos`itions~~
- It makes use of `BlockPos.getAllInBox` to get the positions which are included in the box as a Stream. `BlockPos::toImmutable` is used, to allow these positions to be stored.

I adapted the SurfaceMode (who seemed the only one using that) accordingly.  Why don't Wall and column modes use that too? (Notice that this will make moving to an iterator based approach simpler, as you can just delegate to the iterator in `BoundingBox`).

~~Also I'd request renaming the `schema` Package to `template`. BuildingGadget's doesn't have shematics, it has Templates according to the translation names...~~