### PR TITLE
Fixed block orientation getting lost on copy.

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/common/tainted/inventory/InventoryHelper.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/tainted/inventory/InventoryHelper.java
@@ -48,6 +48,13 @@ public class InventoryHelper {
             ImmutableSet.<Property<?>>builder()
                     .add(CropsBlock.AGE)
                     .add(DoublePlantBlock.HALF)
+                    .add(BlockStateProperties.SOUTH)
+                    .add(BlockStateProperties.EAST)
+                    .add(BlockStateProperties.WEST)
+                    .add(BlockStateProperties.NORTH)
+                    .add(BlockStateProperties.UP)
+                    .add(BlockStateProperties.DOWN)
+                    .add(BlockStateProperties.WATERLOGGED)
                     .build();
 
     public static final CreativeItemIndex CREATIVE_INDEX = new CreativeItemIndex();
@@ -256,25 +263,19 @@ public class InventoryHelper {
     public static Optional<BlockData> getSafeBlockData(PlayerEntity player, BlockPos pos, BlockItemUseContext useContext) {
         World world = player.world;
         BlockState state = world.getBlockState(pos);
-        if (state.getBlock() instanceof FlowingFluidBlock || ! state.getFluidState().isEmpty() )
+        if (state.getBlock() instanceof FlowingFluidBlock)
             return Optional.empty();
         if (state.getBlock() == OurBlocks.CONSTRUCTION_BLOCK.get()) {
             TileEntity te = world.getTileEntity(pos);
             if (te instanceof ConstructionBlockTileEntity) //should already be checked
                 return Optional.of(((ConstructionBlockTileEntity) te).getConstructionBlockData());
         }
-        BlockState placeState = null;
-        try {
-            placeState = state.getBlock().getStateForPlacement(useContext);
-        } catch (Exception e) {
-            ; //this can happen if the context doesn't match how it should be
-        }
-        if (placeState == null)
-            placeState = state.getBlock().getDefaultState();
+        BlockState placeState = state.getBlock().getDefaultState();
         for (Property<?> prop : placeState.getProperties()) {
             if (! UNSAFE_PROPERTIES.contains(prop))
                 placeState = applyProperty(placeState, state, prop);
         }
+
 
         return Optional.of(new BlockData(placeState, TileSupport.createTileData(world, pos)));
     }

--- a/src/main/java/com/direwolf20/buildinggadgets/common/tileentities/ConstructionBlockTileEntity.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/tileentities/ConstructionBlockTileEntity.java
@@ -61,7 +61,6 @@ public class ConstructionBlockTileEntity extends TileEntity {
     public void deserializeNBT(CompoundNBT compound) {
         super.deserializeNBT(compound);
         blockState = BlockData.tryDeserialize(compound.getCompound(NBTKeys.TE_CONSTRUCTION_STATE), true);
-        actualBlockState = BlockData.tryDeserialize(compound.getCompound(NBTKeys.TE_CONSTRUCTION_STATE_ACTUAL), true);
         markDirtyClient();
     }
 
@@ -70,8 +69,6 @@ public class ConstructionBlockTileEntity extends TileEntity {
     public CompoundNBT write(@Nonnull CompoundNBT compound) {
         if (blockState != null) {
             compound.put(NBTKeys.TE_CONSTRUCTION_STATE, blockState.serialize(true));
-            if (actualBlockState != null)
-                compound.put(NBTKeys.TE_CONSTRUCTION_STATE_ACTUAL, actualBlockState.serialize(true));
         }
         return super.write(compound);
     }

--- a/src/main/java/com/direwolf20/buildinggadgets/common/util/GadgetUtils.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/util/GadgetUtils.java
@@ -134,7 +134,6 @@ public class GadgetUtils {
 
     public static void rotateOrMirrorToolBlock(ItemStack stack, PlayerEntity player, PacketRotateMirror.Operation operation) {
         setToolBlock(stack, rotateOrMirrorBlock(player, operation, getToolBlock(stack)));
-        setToolActualBlock(stack, rotateOrMirrorBlock(player, operation, getToolActualBlock(stack)));
     }
 
     private static void setToolBlock(ItemStack stack, @Nullable BlockData data) {
@@ -148,34 +147,13 @@ public class GadgetUtils {
         stack.setTag(tagCompound);
     }
 
-    private static void setToolActualBlock(ItemStack stack, @Nullable BlockData data) {
-        // Store the selected block actual state in the tool's NBT
-        CompoundNBT tagCompound = stack.getOrCreateTag();
-        if (data == null)
-            data = BlockData.AIR;
-
-        CompoundNBT dataTag = data.serialize(true);
-        tagCompound.put(NBTKeys.TE_CONSTRUCTION_STATE_ACTUAL, dataTag);
-        stack.setTag(tagCompound);
-    }
 
     @Nonnull
     public static BlockData getToolBlock(ItemStack stack) {
         CompoundNBT tagCompound = stack.getOrCreateTag();
         BlockData res = BlockData.tryDeserialize(tagCompound.getCompound(NBTKeys.TE_CONSTRUCTION_STATE), true);
         if (res == null) {
-            setToolActualBlock(stack, BlockData.AIR);
-            return BlockData.AIR;
-        }
-        return res;
-    }
-
-    @Nonnull
-    public static BlockData getToolActualBlock(ItemStack stack) {
-        CompoundNBT tagCompound = stack.getOrCreateTag();
-        BlockData res = BlockData.tryDeserialize(tagCompound.getCompound(NBTKeys.TE_CONSTRUCTION_STATE_ACTUAL), true);
-        if (res == null) {
-            setToolActualBlock(stack, BlockData.AIR);
+            setToolBlock(stack, BlockData.AIR);
             return BlockData.AIR;
         }
         return res;
@@ -214,10 +192,7 @@ public class GadgetUtils {
         data.ifPresent(placeState -> {
             BlockState actualState = placeState.getState(); //.getExtendedState(world, lookingAt.getPos()); 1.14 @todo: fix?
 
-            BlockData defaultStateData = new BlockData(placeState.getState().getBlock().getDefaultState(), placeState.getTileData());
-
-            setToolBlock(stack, defaultStateData);
-            setToolActualBlock(stack, new BlockData(actualState, placeState.getTileData()));
+            setToolBlock(stack, new BlockData(actualState, placeState.getTileData()));
         });
 
         return ActionResult.resultSuccess(state.getBlock());
@@ -231,7 +206,6 @@ public class GadgetUtils {
         if (setTool && te instanceof ConstructionBlockTileEntity) {
             ((ConstructionBlockTileEntity) te).getConstructionBlockData();
             setToolBlock(stack, ((ConstructionBlockTileEntity) te).getActualBlockData());
-            setToolActualBlock(stack, ((ConstructionBlockTileEntity) te).getActualBlockData());
             return ActionResultType.SUCCESS;
         }
 

--- a/src/main/java/com/direwolf20/buildinggadgets/common/util/ref/NBTKeys.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/common/util/ref/NBTKeys.java
@@ -103,7 +103,6 @@ public final class NBTKeys {
     public static final String UNIQUE_ITEM_COUNT = "count";
 
     public static final String TE_CONSTRUCTION_STATE = MAP_STATE;
-    public static final String TE_CONSTRUCTION_STATE_ACTUAL = "state_actual";
     public static final String TE_TEMPLATE_MANAGER_ITEMS = "items";
 
     public static final String ENTITY_DESPAWNING = "despawning";


### PR DESCRIPTION
Removed unused ActualBlock state.
Fixed fences, glass panes in a different way as I had to revert the
previous fix to get log rotation to work.
Also allowed copy of waterlogged blocks (waterlogged state is then
dropped).