### PR TITLE
Fix race condition in construction block model building

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets/client/ClientProxy.java
+++ b/src/main/java/com/direwolf20/buildinggadgets/client/ClientProxy.java
@@ -87,8 +87,6 @@ public class ClientProxy {
         ModelResourceLocation ConstrLocation4a = new ModelResourceLocation(ConstrName, "ambient_occlusion=true,bright=true,neighbor_brightness=true");
         IDynamicBakedModel constructionBakedModel = new ConstructionBakedModel();
         IDynamicBakedModel bakedModelLoader = new IDynamicBakedModel() {
-            BlockState facadeState;
-
             @Override
             public boolean isGui3d() {
                 return false;
@@ -112,7 +110,7 @@ public class ClientProxy {
             @Override
             public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, Random rand, IModelData modelData) {
                 IBakedModel model;
-                facadeState = modelData.getData(ConstructionBlockTileEntity.FACADE_STATE);
+                BlockState facadeState = modelData.getData(ConstructionBlockTileEntity.FACADE_STATE);
                 RenderType layer = MinecraftForgeClient.getRenderLayer();
                 if (facadeState == null || facadeState == Blocks.AIR.getDefaultState())
                     facadeState = OurBlocks.CONSTRUCTION_DENSE_BLOCK.get().getDefaultState();
@@ -143,8 +141,6 @@ public class ClientProxy {
         };
 
         IDynamicBakedModel bakedModelLoaderAmbient = new IDynamicBakedModel() {
-            BlockState facadeState;
-
             @Override
             public boolean isGui3d() {
                 return false;
@@ -168,7 +164,7 @@ public class ClientProxy {
             @Override
             public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, Random rand, IModelData modelData) {
                 IBakedModel model;
-                facadeState = modelData.getData(ConstructionBlockTileEntity.FACADE_STATE);
+                BlockState facadeState = modelData.getData(ConstructionBlockTileEntity.FACADE_STATE);
                 RenderType layer = MinecraftForgeClient.getRenderLayer();
                 if (facadeState == null || facadeState == Blocks.AIR.getDefaultState())
                     facadeState = OurBlocks.CONSTRUCTION_DENSE_BLOCK.get().getDefaultState();


### PR DESCRIPTION
When building models for construction blocks, the BlockState is stored in a field within the `IDynamicBakedModel` implementation. Because chunk building occurs over many threads, this can cause a race condition where the field is reassigned after null-checking has already occurred, causing a NullPointerException to be thrown from `RenderTypeLookup`.

This PR should resolve this issue by converting the field to a local variable. 🙂 